### PR TITLE
Fixed (?) a bug wherein GCDAsyncUdpSocket wouldn't report success when entering broadcast mode

### DIFF
--- a/GCD/GCDAsyncUdpSocket.m
+++ b/GCD/GCDAsyncUdpSocket.m
@@ -3449,6 +3449,7 @@ SetParamPtrsAndReturn:
 				[pool drain];
 				return_from_block;
 			}
+			result = YES;
 		}
 		
 		// IPv6 does not implement broadcast, the ability to send a packet to all hosts on the attached link.


### PR DESCRIPTION
the block variable "result" was never being changed from its initial value of NO.

thanks for GCDAsyncUdpSocket.  Very nice work.
