### PR TITLE
NSAutoreleasePools are not released in garbage collected environments.

### DIFF
--- a/RunLoop/AsyncSocket.m
+++ b/RunLoop/AsyncSocket.m
@@ -4291,7 +4291,7 @@ static void MyCFSocketCallback (CFSocketRef sref, CFSocketCallBackType type, CFD
 	AsyncSocket *theSocket = [[(AsyncSocket *)pInfo retain] autorelease];
 	[theSocket doCFSocketCallback:type forSocket:sref withAddress:(NSData *)address withData:pData];
 	
-	[pool release];
+	[pool drain];
 }
 
 /**
@@ -4305,7 +4305,7 @@ static void MyCFReadStreamCallback (CFReadStreamRef stream, CFStreamEventType ty
 	AsyncSocket *theSocket = [[(AsyncSocket *)pInfo retain] autorelease];
 	[theSocket doCFReadStreamCallback:type forStream:stream];
 	
-	[pool release];
+	[pool drain];
 }
 
 /**
@@ -4319,7 +4319,7 @@ static void MyCFWriteStreamCallback (CFWriteStreamRef stream, CFStreamEventType 
 	AsyncSocket *theSocket = [[(AsyncSocket *)pInfo retain] autorelease];
 	[theSocket doCFWriteStreamCallback:type forStream:stream];
 	
-	[pool release];
+	[pool drain];
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/RunLoop/AsyncUdpSocket.m
+++ b/RunLoop/AsyncUdpSocket.m
@@ -2337,7 +2337,7 @@ static void MyCFSocketCallback(CFSocketRef sref, CFSocketCallBackType type, CFDa
 	AsyncUdpSocket *theSocket = [[(AsyncUdpSocket *)pInfo retain] autorelease];
 	[theSocket doCFSocketCallback:type forSocket:sref withAddress:(NSData *)address withData:pData];
 	
-	[pool release];
+	[pool drain];
 }
 
 @end


### PR DESCRIPTION
I am writing an application that uses garbage collection. Because you release the NSAutoreleasePools, they are not actually drained. According to Apple's documentation on NSAutoreleasePools, you should use drain instead of release to support both garbage collected, and retain-count based environments.
