### PR TITLE
Fix an issue where a refused connection will not be cleaned up properly

### DIFF
--- a/GCD/GCDAsyncSocket.m
+++ b/GCD/GCDAsyncSocket.m
@@ -2579,7 +2579,18 @@ enum GCDAsyncSocketConfig
 		
 		accept6Source = NULL;
 	}
-	
+	if (!readSource && !writeSource) {
+		LogVerbose(@"manually closing close");
+
+		if (socket4FD) {
+			close(socket4FD);
+		}
+
+		if (socket6FD) {
+			close(socket6FD);
+		}
+	}
+
 	if (readSource)
 	{
 		LogVerbose(@"dispatch_source_cancel(readSource)");


### PR DESCRIPTION
Socket's are only closed if there is a readSource and a writeSource.
But this isn't the case for failed connections.

If you have enough failed connections, you will eventually hit the MAX_FD limit and not be able to make any new sockets.

This is the same patch as I submitted to https://code.google.com/p/cocoaasyncsocket/issues/detail?id=121
