### PR TITLE
Resume read stream for non-secure streams

### DIFF
--- a/GCD/GCDAsyncSocket.m
+++ b/GCD/GCDAsyncSocket.m
@@ -3848,25 +3848,26 @@ enum GCDAsyncSocketConfig
 		else if (flags & kSocketSecure)
 		{
 			[self flushSSLBuffers];
-			
-			// Edge case:
-			// 
-			// We just drained all data from the ssl buffers,
-			// and all known data from the socket (socketFDBytesAvailable).
-			// 
-			// If we didn't get any data from this process,
-			// then we may have reached the end of the TCP stream.
-			// 
-			// Be sure callbacks are enabled so we're notified about a disconnection.
-			
-			if ([partialReadBuffer length] == 0)
+		}
+
+		// Edge case:
+		//
+		// We just drained all data from the buffers,
+		// and all known data from the socket (socketFDBytesAvailable).
+		//
+		// If we didn't get any data from this process,
+		// then we may have reached the end of the TCP stream.
+		//
+		// Be sure callbacks are enabled so we're notified about a disconnection.
+
+		if ([partialReadBuffer length] == 0)
+		{
+			if ([self usingCFStream]) {
+				// Callbacks never disabled
+			}
+			else
 			{
-				if ([self usingCFStream]) {
-					// Callbacks never disabled
-				}
-				else {
-					[self resumeReadSource];
-				}
+				[self resumeReadSource];
 			}
 		}
 	}


### PR DESCRIPTION
I ran into a bug where my socket reads were timing out.

What appeared to be happening is that while the readSource was suspended, a request was made for more data than was available in the buffer.  Since the buffer was not empty, doReadData ended up in waiting mode - but it never resumes the readSource.

This is likely the same issue as #30
