### PR TITLE
Updated CocoaPod

### DIFF
--- a/CocoaAsyncSocket.podspec
+++ b/CocoaAsyncSocket.podspec
@@ -18,5 +18,9 @@ Pod::Spec.new do |s|
   s.source_files = '{GCD,RunLoop}/*.{h,m}'
   s.clean_paths  = 'Vendor', 'GCD/Xcode', 'RunLoop/Xcode'
   s.requires_arc = true
-  s.frameworks = ['CFNetwork', 'Security']
+  if config.ios?
+    s.frameworks = ['CFNetwork', 'Security']
+  else
+    s.frameworks = ['CoreServices', 'Security']
+  end
 end


### PR DESCRIPTION
I recently tried using the pod specification for CocoaAsyncSocket and came across a couple issues.

Those were:
- I was getting warnings informing me that CocoaAsyncSocket must be built with ARC
- I was getting linking errors by not including the Security framework

I've updated the spec to address these issues.
