### PR TITLE
Minor cleanups

### DIFF
--- a/GCD/GCDAsyncSocket.m
+++ b/GCD/GCDAsyncSocket.m
@@ -7241,22 +7241,42 @@ static void CFWriteStreamCallback (CFWriteStreamRef stream, CFStreamEventType ty
 
 + (NSData *)CRLFData
 {
-	return [NSData dataWithBytes:"\x0D\x0A" length:2];
+    static NSData *data;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        data = [NSData dataWithBytes:"\x0D\x0A" length:2];
+    });
+	return data;
 }
 
 + (NSData *)CRData
 {
-	return [NSData dataWithBytes:"\x0D" length:1];
+    static NSData *data;    
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        data = [NSData dataWithBytes:"\x0D" length:1];
+    });
+	return data;
 }
 
 + (NSData *)LFData
 {
-	return [NSData dataWithBytes:"\x0A" length:1];
+    static NSData *data;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        data = [NSData dataWithBytes:"\x0A" length:1];
+    });
+	return data;
 }
 
 + (NSData *)ZeroData
 {
-	return [NSData dataWithBytes:"" length:1];
+    static NSData *data;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        data = [NSData dataWithBytes:"" length:1];
+    });
+	return data;
 }
 
-@end	
+@end


### PR DESCRIPTION
1)  Will leak SSLContexts on iOS because SSLContext is a Core Foundation type check header doc.

2)  Re-use NSData objects from class methods.
