### PR TITLE
ARC compiling fix: undeclared selector "suspendSend4Source"

### DIFF
--- a/GCD/GCDAsyncUdpSocket.m
+++ b/GCD/GCDAsyncUdpSocket.m
@@ -1701,6 +1701,28 @@ enum GCDAsyncUdpSocketConfig
 	return result;
 }
 
+- (void)suspendSend4Source
+{
+	if (send4Source && !(flags & kSend4SourceSuspended))
+	{
+		LogVerbose(@"dispatch_suspend(send4Source)");
+		
+		dispatch_suspend(send4Source);
+		flags |= kSend4SourceSuspended;
+	}
+}
+
+- (void)suspendSend6Source
+{
+	if (send6Source && !(flags & kSend6SourceSuspended))
+	{
+		LogVerbose(@"dispatch_suspend(send6Source)");
+		
+		dispatch_suspend(send6Source);
+		flags |= kSend6SourceSuspended;
+	}
+}
+
 - (void)setupSendAndReceiveSourcesForSocket4
 {
 	LogTrace();
@@ -2036,28 +2058,6 @@ enum GCDAsyncUdpSocketConfig
 	BOOL useIPv6 = [self isIPv6Enabled];
 	
 	return [self createSocket4:useIPv4 socket6:useIPv6 error:errPtr];
-}
-
-- (void)suspendSend4Source
-{
-	if (send4Source && !(flags & kSend4SourceSuspended))
-	{
-		LogVerbose(@"dispatch_suspend(send4Source)");
-		
-		dispatch_suspend(send4Source);
-		flags |= kSend4SourceSuspended;
-	}
-}
-
-- (void)suspendSend6Source
-{
-	if (send6Source && !(flags & kSend6SourceSuspended))
-	{
-		LogVerbose(@"dispatch_suspend(send6Source)");
-		
-		dispatch_suspend(send6Source);
-		flags |= kSend6SourceSuspended;
-	}
 }
 
 - (void)resumeSend4Source


### PR DESCRIPTION
(NOTE: Sorry for the duplicate pull request. I mean to propose my [90-arc-fix](https://github.com/funkensturm/CocoaAsyncSocket/tree/90-arc-fix) branch, not my master.)

I'm using CocoaAsyncSocket as a cocoapods dependency. As soon as I try to lint my own pod, yours will be cloned and compiled first. However, the compiling does not succeed:

```
 -> CocoaGameSocket (0.0.1)
    - ERROR | XCODEBUILD >  CocoaAsyncSocket/GCD/GCDAsyncUdpSocket.m:1727:5: error: receiver type 'GCDAsyncUdpSocket' for instance message does not declare a method with selector 'suspendSend4Source' [4]
    - ERROR | XCODEBUILD >  CocoaAsyncSocket/GCD/GCDAsyncUdpSocket.m:1732:5: error: receiver type 'GCDAsyncUdpSocket' for instance message does not declare a method with selector 'suspendSend4Source' [4]
    - ERROR | XCODEBUILD >  CocoaAsyncSocket/GCD/GCDAsyncUdpSocket.m:1737:5: error: receiver type 'GCDAsyncUdpSocket' for instance message does not declare a method with selector 'suspendSend4Source' [4]
    - ERROR | XCODEBUILD >  CocoaAsyncSocket/GCD/GCDAsyncUdpSocket.m:1838:5: error: receiver type 'GCDAsyncUdpSocket' for instance message does not declare a method with selector 'suspendSend6Source' [4]
    - ERROR | XCODEBUILD >  CocoaAsyncSocket/GCD/GCDAsyncUdpSocket.m:1843:5: error: receiver type 'GCDAsyncUdpSocket' for instance message does not declare a method with selector 'suspendSend6Source' [4]
    - ERROR | XCODEBUILD >  CocoaAsyncSocket/GCD/GCDAsyncUdpSocket.m:1848:5: error: receiver type 'GCDAsyncUdpSocket' for instance message does not declare a method with selector 'suspendSend6Source' [4]
```

It's essentially because the `suspendSend4Source` and `suspendSend6Source` selectors are not declared in the header file (naturally, because they are just internal methods), yet they are referenced inside the implementation _before_ they are declared.

How do you succeed in building CocoaAsyncSocket after all? I mean, you must have run into this or you have different compile options or cocoapods does something different on my machine than on yours...

At any rate, moving around these two methods a little higher should solve the issue, shouldn't it? Alternatively they could be declared in the header file but that would be rather uncommon for internal methods I guess.
