### PR TITLE
Enable keep-alive packets

### DIFF
--- a/GCD/GCDAsyncSocket.m
+++ b/GCD/GCDAsyncSocket.m
@@ -124,6 +124,7 @@ static const int logLevel = LOG_LEVEL_VERBOSE;
 **/
 #define SOCKET_NULL -1
 
+#define CONN_KEEPIDLE 60
 
 NSString *const GCDAsyncSocketException = @"GCDAsyncSocketException";
 NSString *const GCDAsyncSocketErrorDomain = @"GCDAsyncSocketErrorDomain";
@@ -1800,6 +1801,14 @@ enum GCDAsyncSocketConfig
 	int nosigpipe = 1;
 	setsockopt(childSocketFD, SOL_SOCKET, SO_NOSIGPIPE, &nosigpipe, sizeof(nosigpipe));
 	
+	// Enable keep-alive packets
+	
+	int keepalive = 1;
+	int keepidle = CONN_KEEPIDLE;
+	if (setsockopt(childSocketFD, SOL_SOCKET, SO_KEEPALIVE, &keepalive, sizeof(keepalive)) == noErr) {
+		setsockopt(childSocketFD, IPPROTO_TCP, TCP_KEEPALIVE, &keepidle, sizeof(keepidle));
+	}
+	
 	// Notify delegate
 	
 	if (delegateQueue)
@@ -2381,9 +2390,6 @@ enum GCDAsyncSocketConfig
 		return NO;
 	}
 	
-	int nosigpipe = 1;
-	setsockopt(socketFD, SOL_SOCKET, SO_NOSIGPIPE, &nosigpipe, sizeof(nosigpipe));
-	
 	// Bind the socket to the desired interface (if needed)
 	
 	if (connectInterface)
@@ -2415,6 +2421,14 @@ enum GCDAsyncSocketConfig
 	
 	int nosigpipe = 1;
 	setsockopt(socketFD, SOL_SOCKET, SO_NOSIGPIPE, &nosigpipe, sizeof(nosigpipe));
+	
+	// Enable keep-alive packets
+	
+	int keepalive = 1;
+	int keepidle = CONN_KEEPIDLE;
+	if (setsockopt(childSocketFD, SOL_SOCKET, SO_KEEPALIVE, &keepalive, sizeof(keepalive)) == noErr) {
+		setsockopt(childSocketFD, IPPROTO_TCP, TCP_KEEPALIVE, &keepidle, sizeof(keepidle));
+	}
 	
 	// Start the connection process in a background queue
 	


### PR DESCRIPTION
When the timeout is not specified，the TCP connection will be dead if the connection is terminated unexpectedly.

Because Mac OS X does not have the TCP_KEEPINTVL socket parameter that the interval between packets sent to validate be determined by OS.

<del>Based on my observations, the value is 10 minutes.</del>


Default:
TCP_KEEPINTVL = net.inet.tcp.keepintvl = 75000ms
TCP_KEEPCNT = 8
