### PR TITLE
Merge several pull requests and fix warnings

### DIFF
--- a/GCD/GCDAsyncSocket.m
+++ b/GCD/GCDAsyncSocket.m
@@ -369,7 +369,7 @@ enum GCDAsyncSocketConfig
 
 - (id)initWithCapacity:(size_t)numBytes;
 
-- (void)ensureCapacityForWrite:(size_t)numBytes;
+- (BOOL)ensureCapacityForWrite:(size_t)numBytes;
 
 - (size_t)availableBytes;
 - (uint8_t *)readBuffer;
@@ -411,8 +411,9 @@ enum GCDAsyncSocketConfig
 		free(preBuffer);
 }
 
-- (void)ensureCapacityForWrite:(size_t)numBytes
+- (BOOL)ensureCapacityForWrite:(size_t)numBytes
 {
+	BOOL success;
 	size_t availableSpace = preBufferSize - (writePointer - readPointer);
 	
 	if (numBytes > availableSpace)
@@ -421,16 +422,26 @@ enum GCDAsyncSocketConfig
 		
 		size_t newPreBufferSize = preBufferSize + additionalBytes;
 		uint8_t *newPreBuffer = realloc(preBuffer, newPreBufferSize);
-		
-		size_t readPointerOffset = readPointer - preBuffer;
-		size_t writePointerOffset = writePointer - preBuffer;
-		
-		preBuffer = newPreBuffer;
-		preBufferSize = newPreBufferSize;
-		
-		readPointer = preBuffer + readPointerOffset;
-		writePointer = preBuffer + writePointerOffset;
+		if (newPreBuffer)
+		{
+			size_t readPointerOffset = readPointer - preBuffer;
+			size_t writePointerOffset = writePointer - preBuffer;
+			
+			preBuffer = newPreBuffer;
+			preBufferSize = newPreBufferSize;
+			
+			readPointer = preBuffer + readPointerOffset;
+			writePointer = preBuffer + writePointerOffset;
+			
+			success = YES;
+		}
+		else
+			success = NO;
 	}
+	else
+		success = YES;
+
+	return success;
 }
 
 - (size_t)availableBytes
@@ -3025,6 +3036,17 @@ enum GCDAsyncSocketConfig
 	return [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketClosedError userInfo:userInfo];
 }
 
+- (NSError *)outOfMemoryError
+{
+	NSString *errMsg = NSLocalizedStringWithDefaultValue(@"GCDAsyncSocketOutOfMemoryError",
+	                                                     @"GCDAsyncSocket", [NSBundle mainBundle],
+	                                                     @"Out of memory", nil);
+	
+	NSDictionary *userInfo = [NSDictionary dictionaryWithObject:errMsg forKey:NSLocalizedDescriptionKey];
+
+	return [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketOtherError userInfo:userInfo];
+}
+
 - (NSError *)otherError:(NSString *)errMsg
 {
 	NSDictionary *userInfo = [NSDictionary dictionaryWithObject:errMsg forKey:NSLocalizedDescriptionKey];
@@ -4105,19 +4127,20 @@ enum GCDAsyncSocketConfig
 			
 			CFIndex defaultBytesToRead = (1024 * 4);
 			
-			[preBuffer ensureCapacityForWrite:defaultBytesToRead];
-			
-			uint8_t *buffer = [preBuffer writeBuffer];
-			
-			CFIndex result = CFReadStreamRead(readStream, buffer, defaultBytesToRead);
-			LogVerbose(@"%@ - CFReadStreamRead(): result = %i", THIS_METHOD, (int)result);
-			
-			if (result > 0)
+			if ([preBuffer ensureCapacityForWrite:defaultBytesToRead])
 			{
-				[preBuffer didWrite:result];
+				uint8_t *buffer = [preBuffer writeBuffer];
+
+				CFIndex result = CFReadStreamRead(readStream, buffer, defaultBytesToRead);
+				LogVerbose(@"%@ - CFReadStreamRead(): result = %i", THIS_METHOD, (int)result);
+				
+				if (result > 0)
+				{
+					[preBuffer didWrite:result];
+				}
+				
+				flags &= ~kSecureSocketHasBytesAvailable;
 			}
-			
-			flags &= ~kSecureSocketHasBytesAvailable;
 		}
 		
 		return;
@@ -4161,32 +4184,33 @@ enum GCDAsyncSocketConfig
 			
 			// Make sure there's enough room in the prebuffer
 			
-			[preBuffer ensureCapacityForWrite:estimatedBytesAvailable];
-			
-			// Read data into prebuffer
-			
-			uint8_t *buffer = [preBuffer writeBuffer];
-			size_t bytesRead = 0;
-			
-			OSStatus result = SSLRead(sslContext, buffer, (size_t)estimatedBytesAvailable, &bytesRead);
-			LogVerbose(@"%@ - read from secure socket = %u", THIS_METHOD, (unsigned)bytesRead);
-			
-			if (bytesRead > 0)
+			if ([preBuffer ensureCapacityForWrite:estimatedBytesAvailable])
 			{
-				[preBuffer didWrite:bytesRead];
-			}
-			
-			LogVerbose(@"%@ - prebuffer.length = %zu", THIS_METHOD, [preBuffer availableBytes]);
-			
-			if (result != noErr)
-			{
+				// Read data into prebuffer
+				
+				uint8_t *buffer = [preBuffer writeBuffer];
+				size_t bytesRead = 0;
+				
+				OSStatus result = SSLRead(sslContext, buffer, (size_t)estimatedBytesAvailable, &bytesRead);
+				LogVerbose(@"%@ - read from secure socket = %u", THIS_METHOD, (unsigned)bytesRead);
+				
+				if (bytesRead > 0)
+				{
+					[preBuffer didWrite:bytesRead];
+				}
+				
+				LogVerbose(@"%@ - prebuffer.length = %zu", THIS_METHOD, [preBuffer availableBytes]);
+				
+				if (result != noErr)
+				{
+					done = YES;
+				}
+				else
+				{
+					updateEstimatedBytesAvailable();
+				}
+			} else
 				done = YES;
-			}
-			else
-			{
-				updateEstimatedBytesAvailable();
-			}
-			
 		} while (!done && estimatedBytesAvailable > 0);
 	}
 	
@@ -4520,9 +4544,14 @@ enum GCDAsyncSocketConfig
 		
 		if (readIntoPreBuffer)
 		{
-			[preBuffer ensureCapacityForWrite:bytesToRead];
-						
-			buffer = [preBuffer writeBuffer];
+			if ([preBuffer ensureCapacityForWrite:bytesToRead])
+				buffer = [preBuffer writeBuffer];
+			else
+			{
+				error = [self outOfMemoryError];
+				[self closeWithError:error];
+				return;
+			}
 		}
 		else
 		{
@@ -4755,19 +4784,26 @@ enum GCDAsyncSocketConfig
 						// Copy excess data into preBuffer
 						
 						LogVerbose(@"copying %ld overflow bytes into preBuffer", (long)overflow);
-						[preBuffer ensureCapacityForWrite:overflow];
-						
-						uint8_t *overflowBuffer = buffer + underflow;
-						memcpy([preBuffer writeBuffer], overflowBuffer, overflow);
-						
-						[preBuffer didWrite:overflow];
-						LogVerbose(@"preBuffer.length = %zu", [preBuffer availableBytes]);
-						
-						// Note: The completeCurrentRead method will trim the buffer for us.
-						
-						currentRead->bytesDone += underflow;
-						totalBytesReadForCurrentRead += underflow;
-						done = YES;
+						if ([preBuffer ensureCapacityForWrite:overflow])
+						{
+							uint8_t *overflowBuffer = buffer + underflow;
+							memcpy([preBuffer writeBuffer], overflowBuffer, overflow);
+							
+							[preBuffer didWrite:overflow];
+							LogVerbose(@"preBuffer.length = %zu", [preBuffer availableBytes]);
+							
+							// Note: The completeCurrentRead method will trim the buffer for us.
+							
+							currentRead->bytesDone += underflow;
+							totalBytesReadForCurrentRead += underflow;
+							done = YES;
+						}
+						else
+						{
+							error = [self outOfMemoryError];
+							[self closeWithError:error];
+							return;
+						}
 					}
 					else
 					{
@@ -5984,11 +6020,17 @@ enum GCDAsyncSocketConfig
 			
 			LogVerbose(@"%@: Reading into sslPreBuffer...", THIS_METHOD);
 			
-			[sslPreBuffer ensureCapacityForWrite:socketFDBytesAvailable];
-			
-			readIntoPreBuffer = YES;
-			bytesToRead = (size_t)socketFDBytesAvailable;
-			buf = [sslPreBuffer writeBuffer];
+			if ([sslPreBuffer ensureCapacityForWrite:socketFDBytesAvailable])
+			{
+				readIntoPreBuffer = YES;
+				bytesToRead = (size_t)socketFDBytesAvailable;
+				buf = [sslPreBuffer writeBuffer];
+			}
+			else
+			{
+				socketFDBytesAvailable = 0;
+				return errSSLClosedAbort;
+			}
 		}
 		else
 		{
@@ -6506,14 +6548,18 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 	
 	if (preBufferLength > 0)
 	{
-		[sslPreBuffer ensureCapacityForWrite:preBufferLength];
-		
-		memcpy([sslPreBuffer writeBuffer], [preBuffer readBuffer], preBufferLength);
-		[preBuffer didRead:preBufferLength];
-		[sslPreBuffer didWrite:preBufferLength];
+		if ([sslPreBuffer ensureCapacityForWrite:preBufferLength])
+		{
+			memcpy([sslPreBuffer writeBuffer], [preBuffer readBuffer], preBufferLength);
+			[preBuffer didRead:preBufferLength];
+			[sslPreBuffer didWrite:preBufferLength];
+			sslErrCode = noErr;
+		}
+		else
+			sslErrCode = errSSLClosedAbort;
 	}
-	
-	sslErrCode = noErr;
+	else
+		sslErrCode = noErr;
 	
 	// Start the SSL Handshake process
 	
@@ -6734,11 +6780,14 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 	
 	// We can't run the run loop unless it has an associated input source or a timer.
 	// So we'll just create a timer that will never fire - unless the server runs for decades.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
 	[NSTimer scheduledTimerWithTimeInterval:[[NSDate distantFuture] timeIntervalSinceNow]
 	                                 target:self
 	                               selector:@selector(doNothingAtAll:)
 	                               userInfo:nil
 	                                repeats:YES];
+#pragma clang diagnostic pop
 	
 	[[NSRunLoop currentRunLoop] run];
 	

--- a/GCD/GCDAsyncSocket.m
+++ b/GCD/GCDAsyncSocket.m
@@ -1833,9 +1833,9 @@ enum GCDAsyncSocketConfig
 			
 			// Create GCDAsyncSocket instance for accepted socket
 			
-			GCDAsyncSocket *acceptedSocket = [[GCDAsyncSocket alloc] initWithDelegate:theDelegate
-			                                                            delegateQueue:delegateQueue
-			                                                              socketQueue:childSocketQueue];
+			GCDAsyncSocket *acceptedSocket = [[[self class] alloc] initWithDelegate:theDelegate
+																	  delegateQueue:delegateQueue
+																		socketQueue:childSocketQueue];
 			
 			if (isIPv4)
 				acceptedSocket->socket4FD = childSocketFD;

--- a/GCD/GCDAsyncSocket.m
+++ b/GCD/GCDAsyncSocket.m
@@ -1063,13 +1063,6 @@ enum GCDAsyncSocketConfig : uint32_t
 {
 	if((self = [super init]))
 	{
-		delegate = aDelegate;
-		delegateQueue = dq;
-		
-		#if NEEDS_DISPATCH_RETAIN_RELEASE
-		if (dq) dispatch_retain(dq);
-		#endif
-		
 		socket4FD = SOCKET_NULL;
 		socket6FD = SOCKET_NULL;
 		connectIndex = 0;
@@ -1092,6 +1085,13 @@ enum GCDAsyncSocketConfig : uint32_t
 		{
 			socketQueue = dispatch_queue_create([GCDAsyncSocketQueueName UTF8String], NULL);
 		}
+		
+		delegate = aDelegate;
+		delegateQueue = dq ?: (aDelegate ? socketQueue : NULL);
+		
+		#if NEEDS_DISPATCH_RETAIN_RELEASE
+		if (dq) dispatch_retain(dq);
+		#endif
 		
 		// The dispatch_queue_set_specific() and dispatch_get_specific() functions take a "void *key" parameter.
 		// From the documentation:

--- a/GCD/GCDAsyncSocket.m
+++ b/GCD/GCDAsyncSocket.m
@@ -366,13 +366,6 @@ enum GCDAsyncSocketConfig : uint32_t
 **/
 
 @interface GCDAsyncSocketPreBuffer : NSObject
-{
-	uint8_t *preBuffer;
-	size_t preBufferSize;
-	
-	uint8_t *readPointer;
-	uint8_t *writePointer;
-}
 
 - (id)initWithCapacity:(size_t)numBytes;
 
@@ -396,6 +389,13 @@ enum GCDAsyncSocketConfig : uint32_t
 @end
 
 @implementation GCDAsyncSocketPreBuffer
+{
+	uint8_t *preBuffer;
+	size_t preBufferSize;
+	
+	uint8_t *readPointer;
+	uint8_t *writePointer;
+}
 
 - (id)initWithCapacity:(size_t)numBytes
 {
@@ -520,19 +520,7 @@ enum GCDAsyncSocketConfig : uint32_t
  *  - or simply reading the first chunk of available data
 **/
 @interface GCDAsyncReadPacket : NSObject
-{
-  @public
-	NSMutableData *buffer;
-	NSUInteger startOffset;
-	NSUInteger bytesDone;
-	NSUInteger maxLength;
-	NSTimeInterval timeout;
-	NSUInteger readLength;
-	NSData *term;
-	BOOL bufferOwner;
-	NSUInteger originalBufferLength;
-	long tag;
-}
+
 - (id)initWithData:(NSMutableData *)d
        startOffset:(NSUInteger)s
          maxLength:(NSUInteger)m
@@ -554,6 +542,19 @@ enum GCDAsyncSocketConfig : uint32_t
 @end
 
 @implementation GCDAsyncReadPacket
+{
+  @public
+	NSMutableData *buffer;
+	NSUInteger startOffset;
+	NSUInteger bytesDone;
+	NSUInteger maxLength;
+	NSTimeInterval timeout;
+	NSUInteger readLength;
+	NSData *term;
+	BOOL bufferOwner;
+	NSUInteger originalBufferLength;
+	long tag;
+}
 
 - (id)initWithData:(NSMutableData *)d
        startOffset:(NSUInteger)s
@@ -986,6 +987,10 @@ enum GCDAsyncSocketConfig : uint32_t
  * The GCDAsyncWritePacket encompasses the instructions for any given write.
 **/
 @interface GCDAsyncWritePacket : NSObject
+- (id)initWithData:(NSData *)d timeout:(NSTimeInterval)t tag:(long)i;
+@end
+
+@implementation GCDAsyncWritePacket
 {
   @public
 	NSData *buffer;
@@ -993,10 +998,6 @@ enum GCDAsyncSocketConfig : uint32_t
 	long tag;
 	NSTimeInterval timeout;
 }
-- (id)initWithData:(NSData *)d timeout:(NSTimeInterval)t tag:(long)i;
-@end
-
-@implementation GCDAsyncWritePacket
 
 - (id)initWithData:(NSData *)d timeout:(NSTimeInterval)t tag:(long)i
 {
@@ -1022,14 +1023,14 @@ enum GCDAsyncSocketConfig : uint32_t
  * This class my be altered to support more than just TLS in the future.
 **/
 @interface GCDAsyncSpecialPacket : NSObject
-{
-  @public
-	NSDictionary *tlsSettings;
-}
 - (id)initWithTLSSettings:(NSDictionary *)settings;
 @end
 
 @implementation GCDAsyncSpecialPacket
+{
+  @public
+	NSDictionary *tlsSettings;
+}
 
 - (id)initWithTLSSettings:(NSDictionary *)settings
 {
@@ -1261,7 +1262,7 @@ enum GCDAsyncSocketConfig : uint32_t
 	[self setDelegateQueue:newDelegateQueue synchronously:YES];
 }
 
-- (void)getDelegate:(id *)delegatePtr delegateQueue:(dispatch_queue_t *)delegateQueuePtr
+- (void)getDelegate:(id __autoreleasing *)delegatePtr delegateQueue:(dispatch_queue_t __autoreleasing *)delegateQueuePtr
 {
 	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
 	{
@@ -1469,12 +1470,12 @@ enum GCDAsyncSocketConfig : uint32_t
 #pragma mark Accepting
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-- (BOOL)acceptOnPort:(uint16_t)port error:(NSError **)errPtr
+- (BOOL)acceptOnPort:(uint16_t)port error:(NSError *  __autoreleasing *)errPtr
 {
 	return [self acceptOnInterface:nil port:port error:errPtr];
 }
 
-- (BOOL)acceptOnInterface:(NSString *)inInterface port:(uint16_t)port error:(NSError **)errPtr
+- (BOOL)acceptOnInterface:(NSString *)inInterface port:(uint16_t)port error:(NSError *  __autoreleasing *)errPtr
 {
 	LogTrace();
 	
@@ -1895,7 +1896,7 @@ enum GCDAsyncSocketConfig : uint32_t
  * It is shared between the connectToHost and connectToAddress methods.
  * 
 **/
-- (BOOL)preConnectWithInterface:(NSString *)interface error:(NSError **)errPtr
+- (BOOL)preConnectWithInterface:(NSString *)interface error:(NSError * __autoreleasing *)errPtr
 {
 	NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
 	
@@ -1990,7 +1991,7 @@ enum GCDAsyncSocketConfig : uint32_t
 	return YES;
 }
 
-- (BOOL)connectToHost:(NSString*)host onPort:(uint16_t)port error:(NSError **)errPtr
+- (BOOL)connectToHost:(NSString*)host onPort:(uint16_t)port error:(NSError * __autoreleasing *)errPtr
 {
 	return [self connectToHost:host onPort:port withTimeout:-1 error:errPtr];
 }
@@ -1998,7 +1999,7 @@ enum GCDAsyncSocketConfig : uint32_t
 - (BOOL)connectToHost:(NSString *)host
                onPort:(uint16_t)port
           withTimeout:(NSTimeInterval)timeout
-                error:(NSError **)errPtr
+                error:(NSError * __autoreleasing *)errPtr
 {
 	return [self connectToHost:host onPort:port viaInterface:nil withTimeout:timeout error:errPtr];
 }
@@ -2007,7 +2008,7 @@ enum GCDAsyncSocketConfig : uint32_t
                onPort:(uint16_t)port
          viaInterface:(NSString *)inInterface
           withTimeout:(NSTimeInterval)timeout
-                error:(NSError **)errPtr
+                error:(NSError * __autoreleasing *)errPtr
 {
 	LogTrace();
 	
@@ -2076,12 +2077,12 @@ enum GCDAsyncSocketConfig : uint32_t
 	return result;
 }
 
-- (BOOL)connectToAddress:(NSData *)remoteAddr error:(NSError **)errPtr
+- (BOOL)connectToAddress:(NSData *)remoteAddr error:(NSError * __autoreleasing *)errPtr
 {
 	return [self connectToAddress:remoteAddr viaInterface:nil withTimeout:-1 error:errPtr];
 }
 
-- (BOOL)connectToAddress:(NSData *)remoteAddr withTimeout:(NSTimeInterval)timeout error:(NSError **)errPtr
+- (BOOL)connectToAddress:(NSData *)remoteAddr withTimeout:(NSTimeInterval)timeout error:(NSError * __autoreleasing *)errPtr
 {
 	return [self connectToAddress:remoteAddr viaInterface:nil withTimeout:timeout error:errPtr];
 }
@@ -2089,7 +2090,7 @@ enum GCDAsyncSocketConfig : uint32_t
 - (BOOL)connectToAddress:(NSData *)inRemoteAddr
             viaInterface:(NSString *)inInterface
              withTimeout:(NSTimeInterval)timeout
-                   error:(NSError **)errPtr
+                   error:(NSError * __autoreleasing *)errPtr
 {
 	LogTrace();
 	
@@ -2359,7 +2360,7 @@ enum GCDAsyncSocketConfig : uint32_t
 	[self closeWithError:error];
 }
 
-- (BOOL)connectWithAddress4:(NSData *)address4 address6:(NSData *)address6 error:(NSError **)errPtr
+- (BOOL)connectWithAddress4:(NSData *)address4 address6:(NSData *)address6 error:(NSError * __autoreleasing *)errPtr
 {
 	LogTrace();
 	
@@ -3524,8 +3525,8 @@ enum GCDAsyncSocketConfig : uint32_t
  * 
  * The returned value is a 'struct sockaddr' wrapped in an NSMutableData object.
 **/
-- (void)getInterfaceAddress4:(NSMutableData **)interfaceAddr4Ptr
-                    address6:(NSMutableData **)interfaceAddr6Ptr
+- (void)getInterfaceAddress4:(NSMutableData * __autoreleasing *)interfaceAddr4Ptr
+                    address6:(NSMutableData * __autoreleasing *)interfaceAddr6Ptr
              fromDescription:(NSString *)interfaceDescription
                         port:(uint16_t)port
 {
@@ -7455,7 +7456,7 @@ static void CFWriteStreamCallback (CFWriteStreamRef stream, CFStreamEventType ty
 		return 0;
 }
 
-+ (BOOL)getHost:(NSString **)hostPtr port:(uint16_t *)portPtr fromAddress:(NSData *)address
++ (BOOL)getHost:(NSString * __autoreleasing *)hostPtr port:(uint16_t *)portPtr fromAddress:(NSData *)address
 {
 	if ([address length] >= sizeof(struct sockaddr))
 	{

--- a/GCD/GCDAsyncSocket.m
+++ b/GCD/GCDAsyncSocket.m
@@ -124,6 +124,7 @@ static const int logLevel = LOG_LEVEL_VERBOSE;
 **/
 #define SOCKET_NULL -1
 
+#define CONN_KEEPIDLE 60
 
 NSString *const GCDAsyncSocketException = @"GCDAsyncSocketException";
 NSString *const GCDAsyncSocketErrorDomain = @"GCDAsyncSocketErrorDomain";
@@ -1813,6 +1814,14 @@ enum GCDAsyncSocketConfig
 	int nosigpipe = 1;
 	setsockopt(childSocketFD, SOL_SOCKET, SO_NOSIGPIPE, &nosigpipe, sizeof(nosigpipe));
 	
+	// Enable keep-alive packets
+	
+	int keepalive = 1;
+	int keepidle = CONN_KEEPIDLE;
+	if (setsockopt(childSocketFD, SOL_SOCKET, SO_KEEPALIVE, &keepalive, sizeof(keepalive)) == noErr) {
+		setsockopt(childSocketFD, IPPROTO_TCP, TCP_KEEPALIVE, &keepidle, sizeof(keepidle));
+	}
+	
 	// Notify delegate
 	
 	if (delegateQueue)
@@ -2425,6 +2434,14 @@ enum GCDAsyncSocketConfig
 	
 	int nosigpipe = 1;
 	setsockopt(socketFD, SOL_SOCKET, SO_NOSIGPIPE, &nosigpipe, sizeof(nosigpipe));
+	
+	// Enable keep-alive packets
+	
+	int keepalive = 1;
+	int keepidle = CONN_KEEPIDLE;
+	if (setsockopt(childSocketFD, SOL_SOCKET, SO_KEEPALIVE, &keepalive, sizeof(keepalive)) == noErr) {
+		setsockopt(childSocketFD, IPPROTO_TCP, TCP_KEEPALIVE, &keepidle, sizeof(keepidle));
+	}
 	
 	// Start the connection process in a background queue
 	

--- a/GCD/GCDAsyncSocket.m
+++ b/GCD/GCDAsyncSocket.m
@@ -5682,7 +5682,9 @@ enum GCDAsyncSocketConfig
 		
 		if (!error)
 		{
-			[self maybeDequeueWrite];
+			dispatch_async(socketQueue, ^{
+				[self maybeDequeueWrite];
+			});
 		}
 	}
 	else

--- a/GCD/GCDAsyncSocket.m
+++ b/GCD/GCDAsyncSocket.m
@@ -396,7 +396,9 @@ enum GCDAsyncSocketConfig
 	{
 		preBufferSize = numBytes;
 		preBuffer = malloc(preBufferSize);
-		
+		if (!preBuffer)
+			return nil;
+
 		readPointer = preBuffer;
 		writePointer = preBuffer;
 	}

--- a/GCD/GCDAsyncSocket.m
+++ b/GCD/GCDAsyncSocket.m
@@ -4288,8 +4288,8 @@ enum GCDAsyncSocketConfig : uint32_t
 		return;
 	}
 	
-	BOOL hasBytesAvailable;
-	unsigned long estimatedBytesAvailable;
+	BOOL hasBytesAvailable = NO;
+	unsigned long estimatedBytesAvailable = 0;
 	
 	if ([self usingCFStreamForTLS])
 	{
@@ -6219,7 +6219,7 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 	
 	// Create SSLContext, and setup IO callbacks and connection ref
 	
-	BOOL isServer = [[tlsSettings objectForKey:(NSString *)kCFStreamSSLIsServer] boolValue];
+	Boolean isServer = (Boolean)[[tlsSettings objectForKey:(NSString *)kCFStreamSSLIsServer] boolValue];
 	
 	#if TARGET_OS_IPHONE
 	{
@@ -6301,7 +6301,7 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 		NSAssert(NO, @"Security option unavailable via SecureTransport in iOS - kCFStreamSSLAllowsAnyRoot");
 		#else
 		
-		BOOL allowsAnyRoot = [value boolValue];
+		Boolean allowsAnyRoot = (Boolean)[value boolValue];
 		
 		status = SSLSetAllowsAnyRoot(sslContext, allowsAnyRoot);
 		if (status != noErr)
@@ -6322,7 +6322,7 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 		NSAssert(NO, @"Security option unavailable via SecureTransport in iOS - kCFStreamSSLAllowsExpiredRoots");
 		#else
 		
-		BOOL allowsExpiredRoots = [value boolValue];
+		Boolean allowsExpiredRoots = (Boolean)[value boolValue];
 		
 		status = SSLSetAllowsExpiredRoots(sslContext, allowsExpiredRoots);
 		if (status != noErr)
@@ -6343,7 +6343,7 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 		NSAssert(NO, @"Security option unavailable via SecureTransport in iOS - kCFStreamSSLValidatesCertificateChain");
 		#else
 		
-		BOOL validatesCertChain = [value boolValue];
+		Boolean validatesCertChain = (Boolean)[value boolValue];
 		
 		status = SSLSetEnableCertVerify(sslContext, validatesCertChain);
 		if (status != noErr)
@@ -6364,7 +6364,7 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 		NSAssert(NO, @"Security option unavailable via SecureTransport in iOS - kCFStreamSSLAllowsExpiredCertificates");
 		#else
 		
-		BOOL allowsExpiredCerts = [value boolValue];
+		Boolean allowsExpiredCerts = (Boolean)[value boolValue];
 		
 		status = SSLSetAllowsExpiredCerts(sslContext, allowsExpiredCerts);
 		if (status != noErr)

--- a/README.markdown
+++ b/README.markdown
@@ -1,9 +1,3 @@
-## Fork
-
-This fork of CocoaAsyncSocket merges in a number of pull requests on the original repository, silences compiler warnings, and adds a few small tweaks.
-
-# Original README
-
 CocoaAsyncSocket provides easy-to-use and powerful asynchronous socket libraries for Mac and iOS. The classes are described below.
 
 ## TCP

--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,9 @@
+## Fork
+
+This fork of CocoaAsyncSocket merges in a number of pull requests on the original repository, silences compiler warnings, and adds a few small tweaks.
+
+# Original README
+
 CocoaAsyncSocket provides easy-to-use and powerful asynchronous socket libraries for Mac and iOS. The classes are described below.
 
 ## TCP

--- a/RunLoop/AsyncUdpSocket.m
+++ b/RunLoop/AsyncUdpSocket.m
@@ -253,6 +253,18 @@ static void MyCFSocketCallback(CFSocketRef, CFSocketCallBackType, CFDataRef, con
 		{
 			CFSocketSetSocketFlags(theSocket6, kCFSocketCloseOnInvalidate);
 		}
+        
+        // Prevent sendto calls from sending SIGPIPE signal when socket has been shutdown for writing.
+        // sendto will instead let us handle errors as usual by returning -1.
+        int noSigPipe = 1;
+        if(theSocket4)
+		{
+			setsockopt(CFSocketGetNative(theSocket4), SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, sizeof(noSigPipe));
+		}
+		if(theSocket6)
+		{
+			setsockopt(CFSocketGetNative(theSocket6), SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, sizeof(noSigPipe));
+		}
 		
 		// Get the CFRunLoop to which the socket should be attached.
 		theRunLoop = CFRunLoopGetCurrent();


### PR DESCRIPTION
This covers PRs 116, 115, 100, 77, and 49, makes the code able to build cleanly with `-Weverything`, and defaults a `NULL` socket delegate queue to the socket queue (thereby allowing implicit use of the socket queue without actually providing an accessor).