### PR TITLE
keep socket live even read data time out

### DIFF
--- a/GCD/GCDAsyncSocket.h
+++ b/GCD/GCDAsyncSocket.h
@@ -94,7 +94,7 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 @interface GCDAsyncSocket : NSObject
-
+@property (nonatomic) BOOL keepSocketEvenReadTimeout;
 /**
  * GCDAsyncSocket uses the standard delegate paradigm,
  * but executes all delegate callbacks on a given delegate dispatch queue.

--- a/GCD/GCDAsyncSocket.m
+++ b/GCD/GCDAsyncSocket.m
@@ -1028,6 +1028,7 @@ enum GCDAsyncSocketConfig
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 @implementation GCDAsyncSocket
+@synthesize keepSocketEvenReadTimeout = _keepSocketEvenReadTimeout;
 
 - (id)init
 {
@@ -1107,6 +1108,7 @@ enum GCDAsyncSocketConfig
 		currentWrite = nil;
 		
 		preBuffer = [[GCDAsyncSocketPreBuffer alloc] initWithCapacity:(1024 * 4)];
+        _keepSocketEvenReadTimeout = NO;
 	}
 	return self;
 }
@@ -5172,8 +5174,11 @@ enum GCDAsyncSocketConfig
 		else
 		{
 			LogVerbose(@"ReadTimeout");
-			
-			[self closeWithError:[self readTimeoutError]];
+            if (self.keepSocketEvenReadTimeout) {
+                LogVerbose(@"keep socket live");
+            }else{
+                [self closeWithError:[self readTimeoutError]];
+            }
 		}
 	}
 }


### PR DESCRIPTION
support keep socket live even read data time out.
My application need to read out some info block from an device, but total number of block is unknown until read time  out, so need the socket keep live to more operation.
