### PR TITLE
Update GCD/GCDAsyncSocket.m

### DIFF
--- a/GCD/GCDAsyncSocket.m
+++ b/GCD/GCDAsyncSocket.m
@@ -4244,8 +4244,8 @@ enum GCDAsyncSocketConfig
 		return;
 	}
 	
-	BOOL hasBytesAvailable;
-	unsigned long estimatedBytesAvailable;
+	BOOL hasBytesAvailable = NO;
+	unsigned long estimatedBytesAvailable = 0;
 	
 	if ([self usingCFStreamForTLS])
 	{
@@ -4263,9 +4263,9 @@ enum GCDAsyncSocketConfig
 	}
 	else
 	{
-		#if SECURE_TRANSPORT_MAYBE_AVAILABLE
-		
 		estimatedBytesAvailable = socketFDBytesAvailable;
+		
+		#if SECURE_TRANSPORT_MAYBE_AVAILABLE
 		
 		if (flags & kSocketSecure)
 		{
@@ -4303,9 +4303,9 @@ enum GCDAsyncSocketConfig
 			estimatedBytesAvailable += sslInternalBufSize;
 		}
 		
-		hasBytesAvailable = (estimatedBytesAvailable > 0);
-		
 		#endif
+		
+		hasBytesAvailable = (estimatedBytesAvailable > 0);
 	}
 	
 	if ((hasBytesAvailable == NO) && ([preBuffer availableBytes] == 0))
@@ -4910,7 +4910,7 @@ enum GCDAsyncSocketConfig
 		[self flushSSLBuffers];
 	}
 	
-	BOOL shouldDisconnect;
+	BOOL shouldDisconnect = NO;
 	NSError *error = nil;
 	
 	if ((flags & kStartingReadTLS) || (flags & kStartingWriteTLS))
@@ -5037,7 +5037,7 @@ enum GCDAsyncSocketConfig
 	NSAssert(currentRead, @"Trying to complete current read when there is no current read.");
 	
 	
-	NSData *result;
+	NSData *result = nil;
 	
 	if (currentRead->bufferOwner)
 	{


### PR DESCRIPTION
Fix bugs that prevent the socket from reading any data when the following settings are used to avoid linking with SSL:
# define IS_SECURE_TRANSPORT_AVAILABLE      NO
# define SECURE_TRANSPORT_MAYBE_AVAILABLE   0
# define SECURE_TRANSPORT_MAYBE_UNAVAILABLE 1
