### PR TITLE
Include GCDAsyncUdpSocket.h as the first order of business.

### DIFF
--- a/GCD/GCDAsyncUdpSocket.m
+++ b/GCD/GCDAsyncUdpSocket.m
@@ -8,6 +8,8 @@
 //  https://github.com/robbiehanson/CocoaAsyncSocket
 //
 
+#import "GCDAsyncUdpSocket.h"
+
 #if ! __has_feature(objc_arc)
 #warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
 // For more information see: https://github.com/robbiehanson/CocoaAsyncSocket/wiki/ARC
@@ -38,8 +40,6 @@
   #endif
 
 #endif
-
-#import "GCDAsyncUdpSocket.h"
 
 #if TARGET_OS_IPHONE
   #import <CFNetwork/CFNetwork.h>


### PR DESCRIPTION
Hi Robbie.  I had a spot of bother building the GCDAsyncUdpSocket.m file in Xcode 5.6 with the iOS 6.1 SDK.  It doesn't seem to pull in the TARGET_OS_IPHONE until GCDAsyncUdpSocket.h is included which probably means it needs Foundation.h.  Here's a very simple patch to get it to build.
