### PR TITLE
Fixing a typo that caused trouble for ipv6 udp

### DIFF
--- a/GCD/GCDAsyncUdpSocket.m
+++ b/GCD/GCDAsyncUdpSocket.m
@@ -2265,7 +2265,7 @@ enum GCDAsyncUdpSocketConfig
 			LogWarn(@"Error in getsockname: %@", [self errnoError]);
 		}
 	}
-	else if (socketFamily == AF_INET)
+	else if (socketFamily == AF_INET6)
 	{
 		struct sockaddr_in6 sockaddr6;
 		socklen_t sockaddr6len = sizeof(sockaddr6);


### PR DESCRIPTION
A typo in if statement that I changed prevented ipv6 udp sockets
from updating after binding. Leaving host, port etc empty.
