### PR TITLE
Support for client-side manual trust evaluation (cert pinning) via delegate methods

### DIFF
--- a/GCD/GCDAsyncSocket.h
+++ b/GCD/GCDAsyncSocket.h
@@ -1071,4 +1071,25 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
 **/
 - (void)socketDidSecure:(GCDAsyncSocket *)sock;
 
+#if SECURE_TRANSPORT_MAYBE_AVAILABLE
+/**
+ * Called to determine if the -socket:shouldTrustPeer: callback should be enabled.
+ * Returning YES here will set the SSL session option kSSLSessionOptionBreakOnServerAuth.
+ *
+ * NOTE: Currently only implemented for client sockets. Returning YES in server socket
+ * will terminate the connection.
+**/
+- (BOOL)socketShouldManuallyEvaluateTrust:(GCDAsyncSocket *)sock;
+
+/**
+ * Allows a socket delegate to hook into the TLS handshake and manually validate
+ * the peer it's connecting to.
+ *
+ * This is only called if -socketShouldManuallyEvaluateTrust: returns YES.
+ *
+ * Returning YES continues the SSL handshake, returning NO terminates the handshake
+ * and closes the connection.
+**/
+- (BOOL)socket:(GCDAsyncSocket *)sock shouldTrustPeer:(SecTrustRef)trust;
+#endif
 @end


### PR DESCRIPTION
As per [Apple Technical Note on Server Trust Evaluation](http://developer.apple.com/library/ios/#technotes/tn2232/_index.html), based on work by @dirkx on [client certificates in CocoaHTTPServer](https://github.com/robbiehanson/CocoaHTTPServer/pull/26), I added support for manual trust evaluation in client SSL sockets. 

This also lets us use SecureTransport with invalid/self-signed certificates, for which `kCFStreamSSLValidatesCertificateChain` was needed so far (which would make socket fall back to CF for SSL).
