### PR TITLE
Update podspec to new format 

### DIFF
--- a/CocoaAsyncSocket.podspec
+++ b/CocoaAsyncSocket.podspec
@@ -1,12 +1,21 @@
 Pod::Spec.new do |s|
   s.name     = 'CocoaAsyncSocket'
   s.version  = '7.3.1'
-  s.license  = 'public domain'
-  s.summary  = 'Asynchronous socket networking library for Mac and iOS'
+  s.license  = { :type => 'public domain', :text => <<-LICENSE
+Public Domain License
+
+The CocoaAsyncSocket project is in the public domain.
+
+The original TCP version (AsyncSocket) was created by Dustin Voss in January 2003.
+Updated and maintained by Deusty LLC and the Apple development community.
+                 LICENSE
+               }
+  s.summary  = 'Asynchronous socket networking library for Mac and iOS.'
   s.homepage = 'https://github.com/robbiehanson/CocoaAsyncSocket'
   s.authors  = 'Dustin Voss', { 'Robbie Hanson' => 'robbiehanson@deusty.com' }
 
-  s.source   = { :git => 'https://github.com/robbiehanson/CocoaAsyncSocket.git', :commit => '8407f28d92aff1f95a73274e3f305794fc518a61' }
+  s.source   = { :git => 'https://github.com/robbiehanson/CocoaAsyncSocket.git',
+                 :tag => "#{s.version}" }
 
   s.description = 'CocoaAsyncSocket supports TCP and UDP. The AsyncSocket class is for TCP, and the AsyncUdpSocket class is for UDP. ' \
                   'AsyncSocket is a TCP/IP socket networking library that wraps CFSocket and CFStream. It offers asynchronous ' \
@@ -16,11 +25,13 @@ Pod::Spec.new do |s|
                   'delegate support, run-loop based, self-contained class, and support for IPv4 and IPv6.'
 
   s.source_files = '{GCD,RunLoop}/*.{h,m}'
-  s.clean_paths  = 'Vendor', 'GCD/Xcode', 'RunLoop/Xcode'
+
   s.requires_arc = true
-  if config.ios?
-    s.frameworks = ['CFNetwork', 'Security']
-  else
-    s.frameworks = ['CoreServices', 'Security']
-  end
+
+  # dispatch_queue_set_specific() is available in OS X v10.7+ and iOS 5.0+
+  s.ios.deployment_target = '5.0'
+  s.osx.deployment_target = '10.7'
+
+  s.ios.frameworks = 'CFNetwork', 'Security'
+  s.osx.frameworks = 'CoreServices', 'Security'
 end


### PR DESCRIPTION
Using current podspec results in warning as `clean_paths` are now deprecated.

This is the podspec by @pluton8 from https://github.com/CocoaPods/Specs/blob/master/CocoaAsyncSocket/7.3.1/CocoaAsyncSocket.podspec which has already been updated to new format
