### PR TITLE
Clang diagnostic ignore for the GCDAsyncSocket undeclared selector doNothingAtAll:

### DIFF
--- a/GCD/GCDAsyncSocket.m
+++ b/GCD/GCDAsyncSocket.m
@@ -6732,11 +6732,14 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 	
 	// We can't run the run loop unless it has an associated input source or a timer.
 	// So we'll just create a timer that will never fire - unless the server runs for decades.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
 	[NSTimer scheduledTimerWithTimeInterval:[[NSDate distantFuture] timeIntervalSinceNow]
 	                                 target:self
 	                               selector:@selector(doNothingAtAll:)
 	                               userInfo:nil
 	                                repeats:YES];
+#pragma clang diagnostic pop
 	
 	[[NSRunLoop currentRunLoop] run];
 	


### PR DESCRIPTION
Added a clang diagnostic disable for -Wundeclared-selector in GCDAsyncSocket to silence the missing selector doNothingAtAll:. Since this selector is fake, clang shouldn't need to worry about it not existing.
