### PR TITLE
Initialized variable hasBytesAvailable to fix a warning for OS X target.

### DIFF
--- a/GCD/GCDAsyncSocket.m
+++ b/GCD/GCDAsyncSocket.m
@@ -4244,7 +4244,7 @@ enum GCDAsyncSocketConfig
 		return;
 	}
 	
-	BOOL hasBytesAvailable;
+	BOOL hasBytesAvailable = NO;
 	unsigned long estimatedBytesAvailable;
 	
 	if ([self usingCFStreamForTLS])


### PR DESCRIPTION
Trying to silent a warning raised when using for an OS X target. The thing that is happening is the macro `#if TARGET_OS_IPHONE` (line 4252) is blocking the initialization of `hasBytesAvailable` lines 4258 or 4260, then causing that warning.

I know that the condition `[self usingCFStreamForTLS]` is always false, so it shouldn't cause any random bug, but it was just to keep it warning-free.

Thanks for this truly awesome library :)

Micha
