### PR TITLE
Removed a warning from latest xcode

### DIFF
--- a/GCD/GCDAsyncSocket.m
+++ b/GCD/GCDAsyncSocket.m
@@ -4244,7 +4244,7 @@ enum GCDAsyncSocketConfig
 		return;
 	}
 	
-	BOOL hasBytesAvailable;
+	BOOL hasBytesAvailable = NO;
 	unsigned long estimatedBytesAvailable;
 	
 	if ([self usingCFStreamForTLS])


### PR DESCRIPTION
Warning was:

 Variable 'hasBytesAvailable' is used uninitialized whenever 'if' condition is true

Solution:

Initialise 'hasBytesAvailable' to NO.
