### PR TITLE
Improve connection timeout handling

### DIFF
--- a/GCD/GCDAsyncSocket.h
+++ b/GCD/GCDAsyncSocket.h
@@ -1055,6 +1055,13 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
 - (void)socketDidCloseReadStream:(GCDAsyncSocket *)sock;
 
 /**
+ * Called when a socket was unable to connect.
+ *
+ * Usually, this is because the connection timeout expired.
+**/
+- (void)socketDidNotConnect:(GCDAsyncSocket *)sock error:(NSError *)err;
+
+/**
  * Called when a socket disconnects with or without error.
  * 
  * If you call the disconnect method, and the socket wasn't already disconnected,

--- a/GCD/GCDAsyncSocket.m
+++ b/GCD/GCDAsyncSocket.m
@@ -2649,7 +2649,14 @@ enum GCDAsyncSocketConfig
 	LogTrace();
 	
 	[self endConnectTimeout];
-	[self closeWithError:[self connectTimeoutError]];
+	
+	NSError *error = [self connectTimeoutError];
+	[self closeWithError:error];
+	
+	if ([theDelegate respondsToSelector:@selector(socketDidNotConnect:error:)])
+	{
+		[theDelegate socketDidNotConnect:self error:error];
+	}
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -2792,7 +2799,7 @@ enum GCDAsyncSocketConfig
 	
 	// If the client has passed the connect/accept method, then the connection has at least begun.
 	// Notify delegate that it is now ending.
-	BOOL shouldCallDelegate = (flags & kSocketStarted);
+	BOOL shouldCallDelegate = (flags & kConnected);
 	
 	// Clear stored socket info and all flags (config remains as is)
 	socketFDBytesAvailable = 0;


### PR DESCRIPTION
Currently, when a socket can't connect due to a timeout, the delegate method `socketDidDisconnect:withError:` is called. This is confusing (at least it was to me), because the socket was never connected in the first place. I've added a delegate method `socketDidNotConnect:error:` which is used for this purpose.