### PR TITLE
Fixed analyzer warning in AsyncUdpSocket.m

### DIFF
--- a/RunLoop/AsyncUdpSocket.m
+++ b/RunLoop/AsyncUdpSocket.m
@@ -2076,6 +2076,7 @@ static void MyCFSocketCallback(CFSocketRef, CFSocketCallBackType, CFDataRef, con
 		
 			if([self hasBytesAvailable:theSocket])
 			{
+                NSData* bufferData = nil;
 				ssize_t result;
 				CFSocketNativeHandle theNativeSocket = CFSocketGetNative(theSocket);
 				
@@ -2109,9 +2110,10 @@ static void MyCFSocketCallback(CFSocketRef, CFSocketCallBackType, CFDataRef, con
 							{
 								buf = realloc(buf, result);
 							}
-							theCurrentReceive->buffer = [[NSData alloc] initWithBytesNoCopy:buf
+                            bufferData = [[NSData alloc] initWithBytesNoCopy:buf
 																					 length:result
 																			   freeWhenDone:YES];
+							theCurrentReceive->buffer = bufferData;
 							theCurrentReceive->host = host;
 							theCurrentReceive->port = port;
 						}
@@ -2143,9 +2145,10 @@ static void MyCFSocketCallback(CFSocketRef, CFSocketCallBackType, CFDataRef, con
 							{
 								buf = realloc(buf, result);
 							}
-							theCurrentReceive->buffer = [[NSData alloc] initWithBytesNoCopy:buf
+                            bufferData = [[NSData alloc] initWithBytesNoCopy:buf
 																					 length:result
 																			   freeWhenDone:YES];
+							theCurrentReceive->buffer = bufferData;
 							theCurrentReceive->host = host;
 							theCurrentReceive->port = port;
 						}
@@ -2155,8 +2158,8 @@ static void MyCFSocketCallback(CFSocketRef, CFSocketCallBackType, CFDataRef, con
 				}
 				
 				// Check to see if we need to free our alloc'd buffer
-				// If the buffer is non-nil, this means it has taken ownership of the buffer
-				if(theCurrentReceive->buffer == nil)
+				// If bufferData is non-nil, it has taken ownership of the buffer
+				if(bufferData == nil)
 				{
 					free(buf);
 				}


### PR DESCRIPTION
Fixed analyzer's 'possible leak' warning in -[AsyncUdpSocket
doReceive:] by using an NSData local variable instead of
theCurrentReceive->buffer to do the test of whether'buf' needs to be
freed.
