### PR TITLE
When SSL handshake fails report the peer cert

### DIFF
--- a/GCD/GCDAsyncSocket.m
+++ b/GCD/GCDAsyncSocket.m
@@ -2933,6 +2933,15 @@ enum GCDAsyncSocketConfig
 	return [NSError errorWithDomain:@"kCFStreamErrorDomainSSL" code:ssl_error userInfo:userInfo];
 }
 
+- (NSError *)sslError:(OSStatus)ssl_error peerCertificateDER:(NSData *)peerCertificateDER
+{
+    NSParameterAssert(peerCertificateDER != NULL);
+    NSString *msg = @"Error code definition can be found in Apple's SecureTransport.h";
+    NSDictionary *userInfo = @{NSLocalizedRecoverySuggestionErrorKey : msg,
+                               @"peerCertificateDER" : peerCertificateDER};
+    return [NSError errorWithDomain:@"kCFStreamErrorDomainSSL" code:ssl_error userInfo:userInfo];
+}
+
 - (NSError *)connectTimeoutError
 {
 	NSString *errMsg = NSLocalizedStringWithDefaultValue(@"GCDAsyncSocketConnectTimeoutError",
@@ -6537,7 +6546,27 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 	}
 	else
 	{
-		[self closeWithError:[self sslError:status]];
+        NSData *certData = nil;
+        SecTrustRef trust = NULL;
+        SSLCopyPeerTrust(sslContext, &trust);
+        if (trust) {
+            CFIndex count = SecTrustGetCertificateCount(trust);
+            if (count == 1) {
+                SecCertificateRef cert = SecTrustGetCertificateAtIndex(trust, 0);
+                CFDataRef certDataRef = SecCertificateCopyData(cert);
+                certData = CFBridgingRelease(certDataRef);
+            } else {
+                LogWarn(@"Got too many peer certificated (expected 1 got %d)", count);
+            }
+            CFRelease(trust);
+        }
+        NSError *error;
+        if (certData) {
+            error = [self sslError:status peerCertificateDER:certData];
+        } else {
+            error = [self sslError:status];
+        }
+        [self closeWithError:error];
 	}
 }
 


### PR DESCRIPTION
If the SSL connection fails due to invalid peer's SSL certificate it is very
convenient to have the certificate in the error handler to show it to the user.
The common use case would be to display the certificate to user and ask for
confirmation.

This patch retrieves the certificate and gives it to users' code along side the
NSError.
