### PR TITLE
Fixed bug that prevents data being read from pre buffer if EOF is reached before.

### DIFF
--- a/GCD/GCDAsyncSocket.m
+++ b/GCD/GCDAsyncSocket.m
@@ -3624,10 +3624,7 @@ enum GCDAsyncSocketConfig
 		socketFDBytesAvailable = dispatch_source_get_data(readSource);
 		LogVerbose(@"socketFDBytesAvailable: %lu", socketFDBytesAvailable);
 		
-		if (socketFDBytesAvailable > 0)
-			[self doReadData];
-		else
-			[self doReadEOF];
+		[self doReadData];
 	}});
 	
 	dispatch_source_set_event_handler(writeSource, ^{ @autoreleasepool {


### PR DESCRIPTION
I noticed this issue, which appears only randomly (obviously a race condition), when EOF is reached before all the pre-buffer is read. In that case, the `readSource` event handler:

`dispatch_source_set_event_handler(readSource...`

is called when EOF is reached. In this case, `socketFDBytesAvailable = 0`, so `doReadEOF` was called instead of `doReadData`. Therefore, the data in the pre-buffer was never read.

I fixed that issue by always calling `doReadData`, even when `socketFDBytesAvailable = 0`. It seems like `doReadData` perfectly handles that case, calling then `doReadEOF` at the end.

Feedback from more experimented CocoaAsyncSocketters would be much appreciated :) Please pull if it sounds good. Thanks!
