### PR TITLE
[CRITICAL] Don't trust GCD to give accurate UDP packet sizes.

### DIFF
--- a/GCD/GCDAsyncUdpSocket.m
+++ b/GCD/GCDAsyncUdpSocket.m
@@ -4298,7 +4298,7 @@ enum GCDAsyncUdpSocketConfig
 		size_t bufSize = max4ReceiveSize;
 		void *buf = malloc(bufSize);
 		
-		result = recvfrom(socket4FD, buf, bufSize, MSG_WAITALL, (struct sockaddr *)&sockaddr4, &sockaddr4len);
+		result = recvfrom(socket4FD, buf, bufSize, 0, (struct sockaddr *)&sockaddr4, &sockaddr4len);
 		LogVerbose(@"recvfrom(socket4FD) = %i", (int)result);
 		
 		if (result > 0)

--- a/GCD/GCDAsyncUdpSocket.m
+++ b/GCD/GCDAsyncUdpSocket.m
@@ -4293,10 +4293,12 @@ enum GCDAsyncUdpSocketConfig
 		struct sockaddr_in sockaddr4;
 		socklen_t sockaddr4len = sizeof(sockaddr4);
 		
-		size_t bufSize = MIN(max4ReceiveSize, socket4FDBytesAvailable);
+		// #222: GCD does not necessarily return the size of an entire UDP packet 
+		// from dispatch_source_get_data(), so we must use the maximum packet size.
+		size_t bufSize = max4ReceiveSize;
 		void *buf = malloc(bufSize);
 		
-		result = recvfrom(socket4FD, buf, bufSize, 0, (struct sockaddr *)&sockaddr4, &sockaddr4len);
+		result = recvfrom(socket4FD, buf, bufSize, MSG_WAITALL, (struct sockaddr *)&sockaddr4, &sockaddr4len);
 		LogVerbose(@"recvfrom(socket4FD) = %i", (int)result);
 		
 		if (result > 0)

--- a/GCD/GCDAsyncUdpSocket.m
+++ b/GCD/GCDAsyncUdpSocket.m
@@ -4330,7 +4330,9 @@ enum GCDAsyncUdpSocketConfig
 		struct sockaddr_in6 sockaddr6;
 		socklen_t sockaddr6len = sizeof(sockaddr6);
 		
-		size_t bufSize = MIN(max6ReceiveSize, socket6FDBytesAvailable);
+		// #222: GCD does not necessarily return the size of an entire UDP packet 
+		// from dispatch_source_get_data(), so we must use the maximum packet size.
+		size_t bufSize = max6ReceiveSize;
 		void *buf = malloc(bufSize);
 		
 		result = recvfrom(socket6FD, buf, bufSize, 0, (struct sockaddr *)&sockaddr6, &sockaddr6len);


### PR DESCRIPTION
GCD does not necessarily return the size of an entire UDP packet from `dispatch_source_get_data()`, so we must use the maximum packet size.

**Without this fix, packets can be *silently truncated*, resulting in a loss of data.** I (and others—see comments) have experienced packet truncation "in the wild".