### PR TITLE
Remove "strong" for dispatch_queue_t property

### DIFF
--- a/GCD/GCDAsyncSocket.h
+++ b/GCD/GCDAsyncSocket.h
@@ -90,7 +90,7 @@ typedef enum GCDAsyncSocketError GCDAsyncSocketError;
 #pragma mark Configuration
 
 @property (atomic, weak, readwrite) id delegate;
-@property (atomic, strong, readwrite) dispatch_queue_t delegateQueue;
+@property (atomic, readwrite) dispatch_queue_t delegateQueue;
 
 - (void)getDelegate:(id *)delegatePtr delegateQueue:(dispatch_queue_t *)delegateQueuePtr;
 - (void)setDelegate:(id)delegate delegateQueue:(dispatch_queue_t)delegateQueue;


### PR DESCRIPTION
This change from user mittsh is necessary for CocoaAsyncSocket to compile in the new Xcode. Since dispatch_queue_t is a value type, not a pointer, it's not subject to GC.