### PR TITLE
Notify delegate with explicit error when user disconnects socket

### DIFF
--- a/Source/GCD/GCDAsyncSocket.h
+++ b/Source/GCD/GCDAsyncSocket.h
@@ -55,6 +55,7 @@ typedef NS_ENUM(NSInteger, GCDAsyncSocketError) {
 	GCDAsyncSocketWriteTimeoutError,     // A write operation timed out
 	GCDAsyncSocketReadMaxedOutError,     // Reached set maxLength without completing
 	GCDAsyncSocketClosedError,           // The remote peer closed the connection
+	GCDAsyncSocketDisconnectedError,     // Socket was closed manually
 	GCDAsyncSocketOtherError,            // Description provided in userInfo
 };
 

--- a/Source/GCD/GCDAsyncSocket.m
+++ b/Source/GCD/GCDAsyncSocket.m
@@ -3153,7 +3153,7 @@ enum GCDAsyncSocketConfig
 		
 		if (flags & kSocketStarted)
 		{
-			[self closeWithError:nil];
+			[self closeWithError:[self disconnectedError]];
 		}
 	}};
 	
@@ -3239,7 +3239,7 @@ enum GCDAsyncSocketConfig
 	
 	if (shouldClose)
 	{
-		[self closeWithError:nil];
+		[self closeWithError:[self disconnectedError]];
 	}
 }
 
@@ -3356,6 +3356,17 @@ enum GCDAsyncSocketConfig
 	NSDictionary *userInfo = [NSDictionary dictionaryWithObject:errMsg forKey:NSLocalizedDescriptionKey];
 	
 	return [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketClosedError userInfo:userInfo];
+}
+
+- (NSError *)disconnectedError
+{
+    NSString *errMsg = NSLocalizedStringWithDefaultValue(@"GCDAsyncSocketDisconnectedError",
+	                                                     @"GCDAsyncSocket", [NSBundle mainBundle],
+	                                                     @"Socket was disconnected", nil);
+	
+	NSDictionary *userInfo = [NSDictionary dictionaryWithObject:errMsg forKey:NSLocalizedDescriptionKey];
+	
+	return [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketDisconnectedError userInfo:userInfo];
 }
 
 - (NSError *)otherError:(NSString *)errMsg


### PR DESCRIPTION
Now in the delegate callback we can distinguish 'disconnection' error from any other and silently ignore it if necessary.
