### PR TITLE
Fix occasional crash within SSLWrite caused by failing to reset sslWriteCachedLength to 0 on disconnect.

### DIFF
--- a/GCD/GCDAsyncSocket.m
+++ b/GCD/GCDAsyncSocket.m
@@ -2668,6 +2668,7 @@ enum GCDAsyncSocketConfig
 	// Clear stored socket info and all flags (config remains as is)
 	socketFDBytesAvailable = 0;
 	flags = 0;
+	sslWriteCachedLength = 0;
 	
 	if (shouldCallDelegate)
 	{


### PR DESCRIPTION
Fixes #253.

`doWriteData` maintains state in the form of `sslWriteCachedLength` in order to work around a crock in `SSLWrite`. However, that state was not cleared on socket disconnect. This meant that when writing to the socket after reconnecting, it would be using the bogus `sslWriteCachedLength` from before the disconnect.

In the common case, this will cause the client to write uninitialized garbage to the socket. The heart bleed bug reminded us that it's very bad to send random data from your working set over the wire. :wink: 

Depending on the memory layout and how big `sslWriteCachedLength` is, it will crash reading unmapped memory.

Although I haven't had a chance to write a failing unit test, here's how we managed to reproduce the problem. We would enqueue a large amount of data (in our case ~2MB did it), and then toggle airplane mode on and off. The larger the data you try to send prior to disconnecting, the more likely you'll crash.