### PR TITLE
Handle failure of malloc and realloc

### DIFF
--- a/RunLoop/AsyncSocket.m
+++ b/RunLoop/AsyncSocket.m
@@ -3053,13 +3053,16 @@ Failed:
 	NSData *result = nil;
 	void *sockaddr = malloc(sockaddrlen);
 	
-	if(getpeername(theNativeSocket, (struct sockaddr *)sockaddr, &sockaddrlen) >= 0)
+	if(sockaddr)
 	{
-		result = [NSData dataWithBytesNoCopy:sockaddr length:sockaddrlen freeWhenDone:YES];
-	}
-	else
-	{
-		free(sockaddr);
+		if(getpeername(theNativeSocket, (struct sockaddr *)sockaddr, &sockaddrlen) >= 0)
+		{
+			result = [NSData dataWithBytesNoCopy:sockaddr length:sockaddrlen freeWhenDone:YES];
+		}
+		else
+		{
+			free(sockaddr);
+		}
 	}
 	
 	return result;
@@ -3109,13 +3112,16 @@ Failed:
 	NSData *result = nil;
 	void *sockaddr = malloc(sockaddrlen);
 	
-	if(getsockname(theNativeSocket, (struct sockaddr *)sockaddr, &sockaddrlen) >= 0)
+	if(sockaddr)
 	{
-		result = [NSData dataWithBytesNoCopy:sockaddr length:sockaddrlen freeWhenDone:YES];
-	}
-	else
-	{
-		free(sockaddr);
+		if(getsockname(theNativeSocket, (struct sockaddr *)sockaddr, &sockaddrlen) >= 0)
+		{
+			result = [NSData dataWithBytesNoCopy:sockaddr length:sockaddrlen freeWhenDone:YES];
+		}
+		else
+		{
+			free(sockaddr);
+		}
 	}
 	
 	return result;

--- a/RunLoop/AsyncUdpSocket.m
+++ b/RunLoop/AsyncUdpSocket.m
@@ -2099,6 +2099,10 @@ static void MyCFSocketCallback(CFSocketRef, CFSocketCallBackType, CFDataRef, con
 				void *buf = malloc(maxReceiveBufferSize);
 				size_t bufSize = maxReceiveBufferSize;
 				
+				if(!buf)
+				{
+					result = -1;
+				}
 				if(theSocket == theSocket4)
 				{
 					struct sockaddr_in sockaddr4;
@@ -2121,14 +2125,27 @@ static void MyCFSocketCallback(CFSocketRef, CFSocketCallBackType, CFDataRef, con
 						{
 							if(result != bufSize)
 							{
-								buf = realloc(buf, result);
+								void *newBuf = realloc(buf, result);
+								
+								if(newBuf)
+								{
+									buf = newBuf;
+								}
+								else
+								{
+									result = -1;
+								}
 							}
-                            bufferData = [[NSData alloc] initWithBytesNoCopy:buf
-																					 length:result
-																			   freeWhenDone:YES];
-							theCurrentReceive->buffer = bufferData;
-							theCurrentReceive->host = host;
-							theCurrentReceive->port = port;
+							
+							if(result >= 0)
+							{
+								bufferData = [[NSData alloc] initWithBytesNoCopy:buf
+																						 length:result
+																				   freeWhenDone:YES];
+								theCurrentReceive->buffer = bufferData;
+								theCurrentReceive->host = host;
+								theCurrentReceive->port = port;
+							}
 						}
 					}
 					
@@ -2156,14 +2173,27 @@ static void MyCFSocketCallback(CFSocketRef, CFSocketCallBackType, CFDataRef, con
 						{
 							if(result != bufSize)
 							{
-								buf = realloc(buf, result);
+								void *newBuf = realloc(buf, result);
+								
+								if(newBuf)
+								{
+									buf = newBuf;
+								}
+								else
+								{
+									result = -1;
+								}
 							}
-                            bufferData = [[NSData alloc] initWithBytesNoCopy:buf
-																					 length:result
-																			   freeWhenDone:YES];
-							theCurrentReceive->buffer = bufferData;
-							theCurrentReceive->host = host;
-							theCurrentReceive->port = port;
+							
+							if(result >= 0)
+							{
+								bufferData = [[NSData alloc] initWithBytesNoCopy:buf
+																						 length:result
+																				   freeWhenDone:YES];
+								theCurrentReceive->buffer = bufferData;
+								theCurrentReceive->host = host;
+								theCurrentReceive->port = port;
+							}
 						}
 					}
 					


### PR DESCRIPTION
We use CocoaAsyncSocket in our product, and code analysis tools complain about not checking for allocation failures. Here's how I fixed it
