### PR TITLE
Allow GCDAsyncSocket subclassing

### DIFF
--- a/Source/GCD/GCDAsyncSocket.m
+++ b/Source/GCD/GCDAsyncSocket.m
@@ -1958,9 +1958,9 @@ enum GCDAsyncSocketConfig
 			
 			// Create GCDAsyncSocket instance for accepted socket
 			
-			GCDAsyncSocket *acceptedSocket = [[GCDAsyncSocket alloc] initWithDelegate:theDelegate
-			                                                            delegateQueue:delegateQueue
-			                                                              socketQueue:childSocketQueue];
+			GCDAsyncSocket *acceptedSocket = [[[self class] alloc] initWithDelegate:theDelegate
+																	  delegateQueue:delegateQueue
+																		socketQueue:childSocketQueue];
 			
 			if (socketType == 0)
 				acceptedSocket->socket4FD = childSocketFD;


### PR DESCRIPTION
Allow subclassing of GCDAsyncSocket such that accepted sockets are also the intended class.

Split out and rebased against master from #100.