### PR TITLE
Added MacTarget to Carthage Scheme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ script:
   - xctool -workspace ./Tests/CocoaAsyncSocket.xcworkspace -scheme CocoaAsyncSocketTestsiOS -sdk iphonesimulator -arch i386 test
   - xctool -workspace ./Tests/CocoaAsyncSocket.xcworkspace -scheme CocoaAsyncSocketTestsMac -sdk macosx -arch x86_64 test
   - xctool -project CocoaAsyncSocket.xcodeproj -scheme "iOS Framework" -sdk iphonesimulator -arch i386 build
+  - xctool -project CocoaAsyncSocket.xcodeproj -scheme "Mac Framework" -sdk macosx10.11  -arch x86_64 build

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ script:
   - xctool -workspace ./Tests/CocoaAsyncSocket.xcworkspace -scheme CocoaAsyncSocketTestsiOS -sdk iphonesimulator -arch i386 test
   - xctool -workspace ./Tests/CocoaAsyncSocket.xcworkspace -scheme CocoaAsyncSocketTestsMac -sdk macosx -arch x86_64 test
   - xctool -project CocoaAsyncSocket.xcodeproj -scheme "iOS Framework" -sdk iphonesimulator -arch i386 build
-  - xctool -project CocoaAsyncSocket.xcodeproj -scheme "Mac Framework" -sdk macosx10.11  -arch x86_64 build
+  - xctool -project CocoaAsyncSocket.xcodeproj -scheme "Mac Framework" -sdk macosx10.10  -arch x86_64 build

--- a/CocoaAsyncSocket.xcodeproj/project.pbxproj
+++ b/CocoaAsyncSocket.xcodeproj/project.pbxproj
@@ -16,6 +16,15 @@
 		6CD990391B7789760011A685 /* AsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 6CD990351B7789760011A685 /* AsyncSocket.m */; };
 		6CD9903A1B7789760011A685 /* AsyncUdpSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 6CD990361B7789760011A685 /* AsyncUdpSocket.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6CD9903B1B7789760011A685 /* AsyncUdpSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 6CD990371B7789760011A685 /* AsyncUdpSocket.m */; };
+		9FC41F2C1B9D968000578BEB /* CocoaAsyncSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C55C7D11B7838B1006A7440 /* CocoaAsyncSocket.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9FC41F2D1B9D968700578BEB /* GCDAsyncSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 6CD9902C1B7789680011A685 /* GCDAsyncSocket.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9FC41F2E1B9D968E00578BEB /* GCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 6CD9902D1B7789680011A685 /* GCDAsyncSocket.m */; };
+		9FC41F2F1B9D968E00578BEB /* GCDAsyncUdpSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 6CD9902E1B7789680011A685 /* GCDAsyncUdpSocket.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9FC41F301B9D969100578BEB /* GCDAsyncUdpSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 6CD9902F1B7789680011A685 /* GCDAsyncUdpSocket.m */; };
+		9FC41F311B9D969A00578BEB /* AsyncSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 6CD990341B7789760011A685 /* AsyncSocket.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9FC41F321B9D969F00578BEB /* AsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 6CD990351B7789760011A685 /* AsyncSocket.m */; };
+		9FC41F331B9D96A100578BEB /* AsyncUdpSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 6CD990361B7789760011A685 /* AsyncUdpSocket.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9FC41F341B9D96A600578BEB /* AsyncUdpSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 6CD990371B7789760011A685 /* AsyncUdpSocket.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -30,10 +39,18 @@
 		6CD990351B7789760011A685 /* AsyncSocket.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AsyncSocket.m; path = Source/RunLoop/AsyncSocket.m; sourceTree = SOURCE_ROOT; };
 		6CD990361B7789760011A685 /* AsyncUdpSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AsyncUdpSocket.h; path = Source/RunLoop/AsyncUdpSocket.h; sourceTree = SOURCE_ROOT; };
 		6CD990371B7789760011A685 /* AsyncUdpSocket.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AsyncUdpSocket.m; path = Source/RunLoop/AsyncUdpSocket.m; sourceTree = SOURCE_ROOT; };
+		9FC41F131B9D965000578BEB /* CocoaAsyncSocket.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CocoaAsyncSocket.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		6CD9900C1B77868C0011A685 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9FC41F0F1B9D965000578BEB /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -55,6 +72,7 @@
 			isa = PBXGroup;
 			children = (
 				6CD990101B77868C0011A685 /* CocoaAsyncSocket.framework */,
+				9FC41F131B9D965000578BEB /* CocoaAsyncSocket.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -109,12 +127,24 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		9FC41F101B9D965000578BEB /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9FC41F2C1B9D968000578BEB /* CocoaAsyncSocket.h in Headers */,
+				9FC41F311B9D969A00578BEB /* AsyncSocket.h in Headers */,
+				9FC41F331B9D96A100578BEB /* AsyncUdpSocket.h in Headers */,
+				9FC41F2D1B9D968700578BEB /* GCDAsyncSocket.h in Headers */,
+				9FC41F2F1B9D968E00578BEB /* GCDAsyncUdpSocket.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		6CD9900F1B77868C0011A685 /* CocoaAsyncSocket */ = {
+		6CD9900F1B77868C0011A685 /* iOS CocoaAsyncSocket */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 6CD990241B77868C0011A685 /* Build configuration list for PBXNativeTarget "CocoaAsyncSocket" */;
+			buildConfigurationList = 6CD990241B77868C0011A685 /* Build configuration list for PBXNativeTarget "iOS CocoaAsyncSocket" */;
 			buildPhases = (
 				6CD9900B1B77868C0011A685 /* Sources */,
 				6CD9900C1B77868C0011A685 /* Frameworks */,
@@ -125,9 +155,27 @@
 			);
 			dependencies = (
 			);
-			name = CocoaAsyncSocket;
+			name = "iOS CocoaAsyncSocket";
 			productName = CocoaAsyncSocket;
 			productReference = 6CD990101B77868C0011A685 /* CocoaAsyncSocket.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		9FC41F121B9D965000578BEB /* Mac CocoaAsyncSocket */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9FC41F261B9D965000578BEB /* Build configuration list for PBXNativeTarget "Mac CocoaAsyncSocket" */;
+			buildPhases = (
+				9FC41F0E1B9D965000578BEB /* Sources */,
+				9FC41F0F1B9D965000578BEB /* Frameworks */,
+				9FC41F101B9D965000578BEB /* Headers */,
+				9FC41F111B9D965000578BEB /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Mac CocoaAsyncSocket";
+			productName = "Mac CocoaAsyncSocket";
+			productReference = 9FC41F131B9D965000578BEB /* CocoaAsyncSocket.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -141,6 +189,9 @@
 				TargetAttributes = {
 					6CD9900F1B77868C0011A685 = {
 						CreatedOnToolsVersion = 7.0;
+					};
+					9FC41F121B9D965000578BEB = {
+						CreatedOnToolsVersion = 6.4;
 					};
 				};
 			};
@@ -156,13 +207,21 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				6CD9900F1B77868C0011A685 /* CocoaAsyncSocket */,
+				6CD9900F1B77868C0011A685 /* iOS CocoaAsyncSocket */,
+				9FC41F121B9D965000578BEB /* Mac CocoaAsyncSocket */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		6CD9900E1B77868C0011A685 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9FC41F111B9D965000578BEB /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -180,6 +239,17 @@
 				6CD990331B7789680011A685 /* GCDAsyncUdpSocket.m in Sources */,
 				6CD990311B7789680011A685 /* GCDAsyncSocket.m in Sources */,
 				6CD9903B1B7789760011A685 /* AsyncUdpSocket.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9FC41F0E1B9D965000578BEB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9FC41F321B9D969F00578BEB /* AsyncSocket.m in Sources */,
+				9FC41F301B9D969100578BEB /* GCDAsyncUdpSocket.m in Sources */,
+				9FC41F2E1B9D968E00578BEB /* GCDAsyncSocket.m in Sources */,
+				9FC41F341B9D96A600578BEB /* AsyncUdpSocket.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -286,7 +356,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.robbiehanson.CocoaAsyncSocket;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -303,7 +373,51 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.robbiehanson.CocoaAsyncSocket;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		9FC41F271B9D965000578BEB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		9FC41F281B9D965000578BEB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 			};
 			name = Release;
@@ -320,7 +434,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		6CD990241B77868C0011A685 /* Build configuration list for PBXNativeTarget "CocoaAsyncSocket" */ = {
+		6CD990241B77868C0011A685 /* Build configuration list for PBXNativeTarget "iOS CocoaAsyncSocket" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				6CD990251B77868C0011A685 /* Debug */,
@@ -328,6 +442,14 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		9FC41F261B9D965000578BEB /* Build configuration list for PBXNativeTarget "Mac CocoaAsyncSocket" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9FC41F271B9D965000578BEB /* Debug */,
+				9FC41F281B9D965000578BEB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};

--- a/CocoaAsyncSocket.xcodeproj/xcshareddata/xcschemes/Mac Framework.xcscheme
+++ b/CocoaAsyncSocket.xcodeproj/xcshareddata/xcschemes/Mac Framework.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
-   version = "1.8">
+   LastUpgradeVersion = "0640"
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -14,9 +14,23 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6CD9900F1B77868C0011A685"
-               BuildableName = "iOS CocoaAsyncSocket.framework"
-               BlueprintName = "iOS CocoaAsyncSocket"
+               BlueprintIdentifier = "9FC41F121B9D965000578BEB"
+               BuildableName = "Mac CocoaAsyncSocket.framework"
+               BlueprintName = "Mac CocoaAsyncSocket"
+               ReferencedContainer = "container:CocoaAsyncSocket.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9FC41F1C1B9D965000578BEB"
+               BuildableName = "Mac CocoaAsyncSocketTests.xctest"
+               BlueprintName = "Mac CocoaAsyncSocketTests"
                ReferencedContainer = "container:CocoaAsyncSocket.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -32,9 +46,9 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6CD990191B77868C0011A685"
-               BuildableName = "CocoaAsyncSocketTests.xctest"
-               BlueprintName = "CocoaAsyncSocketTests"
+               BlueprintIdentifier = "9FC41F1C1B9D965000578BEB"
+               BuildableName = "Mac CocoaAsyncSocketTests.xctest"
+               BlueprintName = "Mac CocoaAsyncSocketTests"
                ReferencedContainer = "container:CocoaAsyncSocket.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -42,14 +56,12 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "6CD9900F1B77868C0011A685"
-            BuildableName = "iOS CocoaAsyncSocket.framework"
-            BlueprintName = "iOS CocoaAsyncSocket"
+            BlueprintIdentifier = "9FC41F121B9D965000578BEB"
+            BuildableName = "Mac CocoaAsyncSocket.framework"
+            BlueprintName = "Mac CocoaAsyncSocket"
             ReferencedContainer = "container:CocoaAsyncSocket.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -59,14 +71,13 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
-      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "6CD9900F1B77868C0011A685"
-            BuildableName = "iOS CocoaAsyncSocket.framework"
-            BlueprintName = "iOS CocoaAsyncSocket"
+            BlueprintIdentifier = "9FC41F121B9D965000578BEB"
+            BuildableName = "Mac CocoaAsyncSocket.framework"
+            BlueprintName = "Mac CocoaAsyncSocket"
             ReferencedContainer = "container:CocoaAsyncSocket.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -82,9 +93,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "6CD9900F1B77868C0011A685"
-            BuildableName = "iOS CocoaAsyncSocket.framework"
-            BlueprintName = "iOS CocoaAsyncSocket"
+            BlueprintIdentifier = "9FC41F121B9D965000578BEB"
+            BuildableName = "Mac CocoaAsyncSocket.framework"
+            BlueprintName = "Mac CocoaAsyncSocket"
             ReferencedContainer = "container:CocoaAsyncSocket.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/README.markdown
+++ b/README.markdown
@@ -17,7 +17,19 @@ pod 'CocoaAsyncSocket'
 
 #### Carthage
 
-CocoaAsyncSocket is [Carthage](https://github.com/Carthage/Carthage) compatible. To include it, build your project with Carthage, then drag `Carthage/Build/iOS/CocoaAsyncSocket.framework` into your project.
+CocoaAsyncSocket is [Carthage](https://github.com/Carthage/Carthage) compatible. To include it add the following line to your `Cartfile`
+
+```bash
+github "robbiehanson/CocoaAsyncSocket" "master"
+```
+
+The project is currently configured to build for both **iOS** and **Mac**.  After building with carthage the resultant frameworks will be stored in:
+
+* `Carthage/Build/iOS/CocoaAsyncSocket.framework`
+* `Carthage/Build/Mac/CocoaAsyncSocket.framework`
+
+
+Select the correct framework(s) and drag it into your project.
 
 #### Manual
 


### PR DESCRIPTION
- Added an additional Build target to the project so that Carthage is able to build both an `iOS` target and a `Mac` target.  Updated the travis settings to test the building of the mac target.

Both commands
`carthage build --platform Mac`
`carthage build --platform iOS`

* Updated Project Schemes
* Updated travis CI settings to build both a Mac and an iOS target (to test the frameworks)