### PR TITLE
updating podspec for tvos

### DIFF
--- a/CocoaAsyncSocket.podspec
+++ b/CocoaAsyncSocket.podspec
@@ -30,8 +30,10 @@ Updated and maintained by Deusty LLC and the Apple development community.
 
   # dispatch_queue_set_specific() is available in OS X v10.7+ and iOS 5.0+
   s.ios.deployment_target = '5.0'
+  s.tvos.deployment_target = '9.0'
   s.osx.deployment_target = '10.7'
 
   s.ios.frameworks = 'CFNetwork', 'Security'
+  s.tvos.frameworks = 'CFNetwork', 'Security'
   s.osx.frameworks = 'CoreServices', 'Security'
 end


### PR DESCRIPTION
Recent branches of CocoaPods support tvos as a platform:
https://github.com/CocoaPods/Core/pull/263

It seems that tvOS provides frameworks that CocoaAsyncSocket uses, so we should enable tvos as a supported platform.