### PR TITLE
Fixed issues with building for Mac targets when AppKit headers are not available

### DIFF
--- a/Source/GCD/GCDAsyncSocket.m
+++ b/Source/GCD/GCDAsyncSocket.m
@@ -7916,10 +7916,10 @@ static void CFWriteStreamCallback (CFWriteStreamRef stream, CFStreamEventType ty
 		return NO;
 	}
 	
-	BOOL r1, r2;
-	
 	LogVerbose(@"Enabling backgrouding on socket");
 	
+#if !TARGET_OS_TV
+    BOOL r1, r2;
 	r1 = CFReadStreamSetProperty(readStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeVoIP);
 	r2 = CFWriteStreamSetProperty(writeStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeVoIP);
 	
@@ -7927,7 +7927,7 @@ static void CFWriteStreamCallback (CFWriteStreamRef stream, CFStreamEventType ty
 	{
 		return NO;
 	}
-	
+#endif
 	if (!caveat)
 	{
 		if (![self openStreams])

--- a/Source/GCD/GCDAsyncUdpSocket.m
+++ b/Source/GCD/GCDAsyncUdpSocket.m
@@ -1920,7 +1920,7 @@ enum GCDAsyncUdpSocketConfig
 	flags |= kReceive6SourceSuspended;
 }
 
-- (BOOL)createSocket4:(BOOL)useIPv4 socket6:(BOOL)useIPv6 error:(NSError **)errPtr
+- (BOOL)createSocket4:(BOOL)useIPv4 socket6:(BOOL)useIPv6 error:(__autoreleasing NSError **)errPtr
 {
 	LogTrace();
 	

--- a/Source/Vendor/CocoaLumberjack/DDFileLogger.h
+++ b/Source/Vendor/CocoaLumberjack/DDFileLogger.h
@@ -231,7 +231,7 @@
 // You can optionally force the current log file to be rolled with this method.
 // CompletionBlock will be called on main queue.
 
-- (void)rollLogFileWithCompletionBlock:(void (^)())completionBlock;
+- (void)rollLogFileWithCompletionBlock:(void (^)(void))completionBlock;
 
 // Method is deprecated. Use rollLogFileWithCompletionBlock: method instead.
 

--- a/Source/Vendor/CocoaLumberjack/DDFileLogger.m
+++ b/Source/Vendor/CocoaLumberjack/DDFileLogger.m
@@ -768,7 +768,7 @@ BOOL doesAppRunInBackground(void);
     [self rollLogFileWithCompletionBlock:nil];
 }
 
-- (void)rollLogFileWithCompletionBlock:(void (^)())completionBlock
+- (void)rollLogFileWithCompletionBlock:(void (^)(void))completionBlock
 {
     // This method is public.
     // We need to execute the rolling on our logging thread/queue.

--- a/Source/Vendor/CocoaLumberjack/DDLog.m
+++ b/Source/Vendor/CocoaLumberjack/DDLog.m
@@ -142,7 +142,7 @@ static unsigned int numProcessors;
         
         // Figure out how many processors are available.
         // This may be used later for an optimization on uniprocessor machines.
-        
+#if !TARGET_OS_TV
         host_basic_info_data_t hostInfo;
         mach_msg_type_number_t infoCount;
         
@@ -155,7 +155,7 @@ static unsigned int numProcessors;
         numProcessors = MAX(result, one);
         
         NSLogDebug(@"DDLog: numProcessors = %u", numProcessors);
-            
+#endif
         
     #if TARGET_OS_IPHONE
         NSString *notificationName = @"UIApplicationWillTerminateNotification";

--- a/Source/Vendor/CocoaLumberjack/DDLog.m
+++ b/Source/Vendor/CocoaLumberjack/DDLog.m
@@ -57,6 +57,13 @@
 
 static void *const GlobalLoggingQueueIdentityKey = (void *)&GlobalLoggingQueueIdentityKey;
 
+#if !TARGET_OS_IPHONE
+@interface NSObject (DDLackOfAppKitNSApplicationWorkaround)
+- (id)sharedApplication;
+- (NSUInteger)occlusionState;
+@end
+#endif
+
 
 @interface DDLoggerNode : NSObject {
 @public 
@@ -155,7 +162,7 @@ static unsigned int numProcessors;
     #else
         NSString *notificationName = nil;
 
-        if (NSApp)
+        if ([NSClassFromString(@"NSApplication") sharedApplication] != NULL)
         {
             notificationName = @"NSApplicationWillTerminateNotification";
         }
@@ -908,7 +915,7 @@ static char *dd_str_copy(const char *str)
                 #endif
                 floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_6_1 // iOS 7+ (> iOS 6.1)
             #else
-                [[NSApplication sharedApplication] respondsToSelector:@selector(occlusionState)] // OS X 10.9+
+                [[NSClassFromString(@"NSApplication") sharedApplication] respondsToSelector:@selector(occlusionState)] // OS X 10.9+
             #endif
             ) {
             queueLabel = dd_str_copy(dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL));
@@ -925,7 +932,7 @@ static char *dd_str_copy(const char *str)
             #endif
             floor(NSFoundationVersionNumber) < NSFoundationVersionNumber_iOS_6_0 // < iOS 6.0
         #else
-            ![[NSApplication sharedApplication] respondsToSelector:@selector(occlusionState)] // < OS X 10.9
+            ![[NSClassFromString(@"NSApplication") sharedApplication] respondsToSelector:@selector(occlusionState)] // < OS X 10.9
         #endif
             ) {
             #pragma clang diagnostic push


### PR DESCRIPTION
This change addresses some issues with the build of CocoaLumberjack that is included when building for targets that do not link to or import the AppKit framework headers. Instead of referencing NSApp or NSApplication classes directly, the NSApplication class is detected/accessed through a call to NSClassFromString using the "NSApplication" class name.
