### PR TITLE
Rename variable to prevent warning

### DIFF
--- a/Source/GCD/GCDAsyncSocket.m
+++ b/Source/GCD/GCDAsyncSocket.m
@@ -2426,10 +2426,10 @@ enum GCDAsyncSocketConfig
 		
 		// Start the normal connection process
 		
-		NSError *err = nil;
-		if (![self connectWithAddressUN:connectInterfaceUN error:&err])
+		NSError *connectError = nil;
+		if (![self connectWithAddressUN:connectInterfaceUN error:&connectError])
 		{
-			[self closeWithError:err];
+			[self closeWithError:connectError];
 			
 			return_from_block;
 		}


### PR DESCRIPTION
Compiling the source outputs a warning (either with Xcode or Carthage)

> CocoaAsyncSocket/Source/GCD/GCDAsyncSocket.m:2429:12: warning: declaration shadows a local variable [-Wshadow]

This PR simply renamed the variable to remove the warning.