### PR TITLE
GCD timers may be very inaccurate at least when combined with App Nap on OS X. DISPATCH_TIMER_STRICT flag fixes the problem.

### DIFF
--- a/Source/GCD/GCDAsyncSocket.m
+++ b/Source/GCD/GCDAsyncSocket.m
@@ -2895,7 +2895,7 @@ enum GCDAsyncSocketConfig
 {
 	if (timeout >= 0.0)
 	{
-		connectTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, socketQueue);
+		connectTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, DISPATCH_TIMER_STRICT, socketQueue);
 		
 		__weak GCDAsyncSocket *weakSelf = self;
 		
@@ -5549,7 +5549,7 @@ enum GCDAsyncSocketConfig
 {
 	if (timeout >= 0.0)
 	{
-		readTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, socketQueue);
+		readTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, DISPATCH_TIMER_STRICT, socketQueue);
 		
 		__weak GCDAsyncSocket *weakSelf = self;
 		
@@ -6192,7 +6192,7 @@ enum GCDAsyncSocketConfig
 {
 	if (timeout >= 0.0)
 	{
-		writeTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, socketQueue);
+		writeTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, DISPATCH_TIMER_STRICT, socketQueue);
 		
 		__weak GCDAsyncSocket *weakSelf = self;
 		

--- a/Source/GCD/GCDAsyncUdpSocket.m
+++ b/Source/GCD/GCDAsyncUdpSocket.m
@@ -4083,7 +4083,7 @@ enum GCDAsyncUdpSocketConfig
 	
 	LogTrace();
 	
-	sendTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, socketQueue);
+	sendTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, DISPATCH_TIMER_STRICT, socketQueue);
 	
 	dispatch_source_set_event_handler(sendTimer, ^{ @autoreleasepool {
 		


### PR DESCRIPTION
Accurate network timeout timers may be critical requirement for some applications. However energy efficiency features (such as App Nap) may postpone a timer for a significant time, in my experience App Nap postpones up to 10 seconds.

A simple example app, which creates a socket and sends ping each 10 seconds when read timeout occurs gives result like:

```
2016-03-09 21:12:34.889 did connect
2016-03-09 21:12:44.890 should timeout read with elapsed 10.000000 (actually last read was 10.000101 seconds ago)
2016-03-09 21:12:44.890 did send ping
2016-03-09 21:12:44.936 did receive ping
2016-03-09 21:12:54.938 should timeout read with elapsed 10.000000 (actually last read was 10.001128 seconds ago)
2016-03-09 21:12:54.938 did send ping
2016-03-09 21:12:55.003 did receive ping
2016-03-09 21:13:05.004 should timeout read with elapsed 10.000000 (actually last read was 10.000230 seconds ago)
2016-03-09 21:13:05.004 did send ping
2016-03-09 21:13:05.049 did receive ping
2016-03-09 21:13:15.049 should timeout read with elapsed 10.000000 (actually last read was 10.000083 seconds ago)
2016-03-09 21:13:15.050 did send ping
2016-03-09 21:13:15.095 did receive ping
2016-03-09 21:13:30.146 should timeout read with elapsed 10.000000 (actually last read was 15.050761 seconds ago)
2016-03-09 21:13:30.146 did send ping
2016-03-09 21:13:30.191 did receive ping
2016-03-09 21:13:50.192 should timeout read with elapsed 10.000000 (actually last read was 20.000131 seconds ago)
2016-03-09 21:13:50.192 did send ping
2016-03-09 21:13:50.237 did receive ping
2016-03-09 21:14:00.238 should timeout read with elapsed 10.000000 (actually last read was 10.000338 seconds ago)
2016-03-09 21:14:00.238 did send ping
2016-03-09 21:14:00.283 did receive ping
2016-03-09 21:14:20.283 should timeout read with elapsed 10.000000 (actually last read was 19.999992 seconds ago)
2016-03-09 21:14:20.284 did send ping
2016-03-09 21:14:20.329 did receive ping
2016-03-09 21:14:40.329 should timeout read with elapsed 10.000000 (actually last read was 20.000327 seconds ago)
```

A minimal o zero leeway does not help, but DISPATCH_TIMER_STRICT flag fixes the problem completely.
