### PR TITLE
Do not consider errSSLPeerAuthCompleted as error

### DIFF
--- a/Source/GCD/GCDAsyncSocket.m
+++ b/Source/GCD/GCDAsyncSocket.m
@@ -4993,10 +4993,10 @@ enum GCDAsyncSocketConfig
 					
 					bytesRead += loop_bytesRead;
 					
-				} while ((result == noErr) && (bytesRead < bytesToRead));
+				} while ((result == noErr || result == errSSLPeerAuthCompleted) && (bytesRead < bytesToRead));
 				
 				
-				if (result != noErr)
+				if (result != noErr && result != errSSLPeerAuthCompleted)
 				{
 					if (result == errSSLWouldBlock)
 						waiting = YES;


### PR DESCRIPTION
Some servers are generating the status `errSSLPeerAuthCompleted` during the SSL flow, and outside the handshake, and we might just ignore it safely and resume the transfer. This happens when a server is optionally requiring an SSL certificate.

I'm not sure if the servers here are to blame on their implementation of SSL, but anyway it was failing for me on some HTTPS servers. This addresses the issue.
