### PR TITLE
Fix a warning when converting size_t to uchar

### DIFF
--- a/Source/GCD/GCDAsyncSocket.m
+++ b/Source/GCD/GCDAsyncSocket.m
@@ -4014,7 +4014,7 @@ enum GCDAsyncSocketConfig
     struct sockaddr_un nativeAddr;
     nativeAddr.sun_family = AF_UNIX;
     strlcpy(nativeAddr.sun_path, path.fileSystemRepresentation, sizeof(nativeAddr.sun_path));
-    nativeAddr.sun_len = SUN_LEN(&nativeAddr);
+    nativeAddr.sun_len = (unsigned char)SUN_LEN(&nativeAddr);
     NSData *interface = [NSData dataWithBytes:&nativeAddr length:sizeof(struct sockaddr_un)];
 	
 	return interface;


### PR DESCRIPTION
Fix a warning when assigning a `size_t` value to an `unsigned char`. It's happening for an OS X app (maybe it doesn't happen on iOS…).
