### PR TITLE
Try to connect to both IPv4 and IPv6 addresses

### DIFF
--- a/Source/GCD/GCDAsyncSocket.m
+++ b/Source/GCD/GCDAsyncSocket.m
@@ -2619,6 +2619,8 @@ enum GCDAsyncSocketConfig
             
             if (result == 0)
             {
+                [self closeUnusedSocket:socketFD];
+                
                 [strongSelf didConnect:aStateIndex];
             }
             else
@@ -2640,7 +2642,8 @@ enum GCDAsyncSocketConfig
     LogVerbose(@"Connecting...");
 }
 
-- (void)closeSocket:(int)socketFD {
+- (void)closeSocket:(int)socketFD
+{
     if (socketFD != SOCKET_NULL)
     {
         close(socketFD);
@@ -2655,6 +2658,18 @@ enum GCDAsyncSocketConfig
             LogVerbose(@"close(socket6FD)");
             socket6FD = SOCKET_NULL;
         }
+    }
+}
+
+- (void)closeUnusedSocket:(int)usedSocketFD
+{
+    if (usedSocketFD != socket4FD)
+    {
+        [self closeSocket:socket4FD];
+    }
+    else if (usedSocketFD != socket6FD)
+    {
+        [self closeSocket:socket6FD];
     }
 }
 
@@ -2716,7 +2731,7 @@ enum GCDAsyncSocketConfig
     
     if (alternateAddress)
     {
-        NSTimeInterval alternateAddressDelay = 0.5;
+        NSTimeInterval alternateAddressDelay = 0.3;
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(alternateAddressDelay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
             [self connectSocket:alternateSocketFD address:alternateAddress stateIndex:aStateIndex];
         });

--- a/Tests/Shared/GCDAsyncSocketConnectionTests.m
+++ b/Tests/Shared/GCDAsyncSocketConnectionTests.m
@@ -56,6 +56,84 @@ static const uint16_t kTestPort = 30301;
     }];
 }
 
+- (void)testConnectionWithAnIPv4OnlyServer {
+    self.serverSocket.IPv6Enabled = NO;
+    
+    NSError *error = nil;
+    BOOL success = NO;
+    success = [self.serverSocket acceptOnPort:kTestPort error:&error];
+    XCTAssertTrue(success, @"Server failed setting up socket on port %d %@", kTestPort, error);
+    success = [self.clientSocket connectToHost:@"127.0.0.1" onPort:kTestPort error:&error];
+    XCTAssertTrue(success, @"Client failed connecting to up server socket on port %d %@", kTestPort, error);
+    
+    self.expectation = [self expectationWithDescription:@"Test Full Connection"];
+    [self waitForExpectationsWithTimeout:30 handler:^(NSError *error) {
+        if (error) {
+            NSLog(@"Error establishing test connection");
+        }
+        else {
+            XCTAssertTrue(self.acceptedServerSocket.isIPv4, @"Established connection is not IPv4");
+        }
+    }];
+}
+
+- (void)testConnectionWithAnIPv6OnlyServer {
+    self.serverSocket.IPv4Enabled = NO;
+    
+    NSError *error = nil;
+    BOOL success = NO;
+    success = [self.serverSocket acceptOnPort:kTestPort error:&error];
+    XCTAssertTrue(success, @"Server failed setting up socket on port %d %@", kTestPort, error);
+    success = [self.clientSocket connectToHost:@"::1" onPort:kTestPort error:&error];
+    XCTAssertTrue(success, @"Client failed connecting to up server socket on port %d %@", kTestPort, error);
+    
+    self.expectation = [self expectationWithDescription:@"Test Full Connection"];
+    [self waitForExpectationsWithTimeout:30 handler:^(NSError *error) {
+        if (error) {
+            NSLog(@"Error establishing test connection");
+        }
+        else {
+            XCTAssertTrue(self.acceptedServerSocket.isIPv6, @"Established connection is not IPv6");
+        }
+    }];
+}
+
+- (void)testConnectionWithLocalhostWithClientPreferringIPv4 {
+    [self.clientSocket setIPv4PreferredOverIPv6:YES];
+    
+    NSError *error = nil;
+    BOOL success = NO;
+    success = [self.serverSocket acceptOnPort:kTestPort error:&error];
+    XCTAssertTrue(success, @"Server failed setting up socket on port %d %@", kTestPort, error);
+    success = [self.clientSocket connectToHost:@"localhost" onPort:kTestPort error:&error];
+    XCTAssertTrue(success, @"Client failed connecting to up server socket on port %d %@", kTestPort, error);
+    
+    self.expectation = [self expectationWithDescription:@"Test Full Connection"];
+    [self waitForExpectationsWithTimeout:30 handler:^(NSError *error) {
+        if (error) {
+            NSLog(@"Error establishing test connection");
+        }
+    }];
+}
+
+- (void)testConnectionWithLocalhostWithClientPreferringIPv6 {
+    [self.clientSocket setIPv4PreferredOverIPv6:NO];
+
+    NSError *error = nil;
+    BOOL success = NO;
+    success = [self.serverSocket acceptOnPort:kTestPort error:&error];
+    XCTAssertTrue(success, @"Server failed setting up socket on port %d %@", kTestPort, error);
+    success = [self.clientSocket connectToHost:@"localhost" onPort:kTestPort error:&error];
+    XCTAssertTrue(success, @"Client failed connecting to up server socket on port %d %@", kTestPort, error);
+    
+    self.expectation = [self expectationWithDescription:@"Test Full Connection"];
+    [self waitForExpectationsWithTimeout:30 handler:^(NSError *error) {
+        if (error) {
+            NSLog(@"Error establishing test connection");
+        }
+    }];
+}
+
 #pragma mark GCDAsyncSocketDelegate methods
 
 /**

--- a/Tests/Shared/SwiftTests.swift
+++ b/Tests/Shared/SwiftTests.swift
@@ -56,7 +56,98 @@ class SwiftTests: XCTestCase, GCDAsyncSocketDelegate {
             }
         }
     }
+    
+    func testConnectionWithAnIPv4OnlyServer() {
+        serverSocket?.IPv6Enabled = false
+        do {
+            try serverSocket?.acceptOnPort(kTestPort)
+        } catch {
+            XCTFail("\(error)")
+        }
+        do {
+            try clientSocket?.connectToHost("127.0.0.1", onPort: kTestPort)
+        } catch {
+            XCTFail("\(error)")
+        }
+        expectation = expectationWithDescription("Test Full connnection")
+        waitForExpectationsWithTimeout(30) { (error: NSError?) -> Void in
+            if error != nil {
+                XCTFail("\(error)")
+            }
+            else {
+                if let isIPv4 = self.acceptedServerSocket?.isIPv4 {
+                    XCTAssertTrue(isIPv4)
+                }
+            }
+        }
+    }
 
+    func testConnectionWithAnIPv6OnlyServer() {
+        serverSocket?.IPv4Enabled = false
+        do {
+            try serverSocket?.acceptOnPort(kTestPort)
+        } catch {
+            XCTFail("\(error)")
+        }
+        do {
+            try clientSocket?.connectToHost("::1", onPort: kTestPort)
+        } catch {
+            XCTFail("\(error)")
+        }
+        expectation = expectationWithDescription("Test Full connnection")
+        waitForExpectationsWithTimeout(30) { (error: NSError?) -> Void in
+            if error != nil {
+                XCTFail("\(error)")
+            }
+            else {
+                if let isIPv6 = self.acceptedServerSocket?.isIPv6 {
+                    XCTAssertTrue(isIPv6)
+                }
+            }
+        }
+    }
+    
+    func testConnectionWithLocalhostWithClientPreferringIPv4() {
+        clientSocket?.IPv4PreferredOverIPv6 = true
+        
+        do {
+            try serverSocket?.acceptOnPort(kTestPort)
+        } catch {
+            XCTFail("\(error)")
+        }
+        do {
+            try clientSocket?.connectToHost("localhost", onPort: kTestPort)
+        } catch {
+            XCTFail("\(error)")
+        }
+        expectation = expectationWithDescription("Test Full connnection")
+        waitForExpectationsWithTimeout(30) { (error: NSError?) -> Void in
+            if error != nil {
+                XCTFail("\(error)")
+            }
+        }
+    }
+    
+    func testConnectionWithLocalhostWithClientPreferringIPv6() {
+        clientSocket?.IPv4PreferredOverIPv6 = false
+        
+        do {
+            try serverSocket?.acceptOnPort(kTestPort)
+        } catch {
+            XCTFail("\(error)")
+        }
+        do {
+            try clientSocket?.connectToHost("localhost", onPort: kTestPort)
+        } catch {
+            XCTFail("\(error)")
+        }
+        expectation = expectationWithDescription("Test Full connnection")
+        waitForExpectationsWithTimeout(30) { (error: NSError?) -> Void in
+            if error != nil {
+                XCTFail("\(error)")
+            }
+        }
+    }
     
     //MARK:- GCDAsyncSocketDelegate
     func socket(sock: GCDAsyncSocket!, didAcceptNewSocket newSocket: GCDAsyncSocket!) {


### PR DESCRIPTION
If a host has both IPv4 and IPv6 addresses, try to connect to the preferred one first and the other one after a delay. Keep the first connection to succeed and discard the other one.

This pull request is a possible solution to the issue described in [https://github.com/robbiehanson/XMPPFramework/issues/718](url). It is based on the idea of the Happy Eyeballs algorithm, although it is not a complete implementation of it, as it does not cache connection successes and failures.

I tried to modify as few lines of code as possible, although I had to extract a few methods to be able to reuse them for the connection to both addresses.