### PR TITLE
Added failover.

### DIFF
--- a/Source/GCD/GCDAsyncSocket.h
+++ b/Source/GCD/GCDAsyncSocket.h
@@ -128,12 +128,14 @@ typedef NS_ENUM(NSInteger, GCDAsyncSocketError) {
 @property (atomic, assign, readwrite, getter=isIPv4PreferredOverIPv6) BOOL IPv4PreferredOverIPv6;
 
 /** 
- * When connecting to both IPv4 and IPv6 using Happy Eyeballs (RFC 6555) https://tools.ietf.org/html/rfc6555
- * this is the delay between connecting to the preferred protocol and the fallback protocol.
+ * When connecting to a FQDN which have multiple DNS A records this is the timeout
+ * for connecting to each given record.
+ * *NOTE* This is a different value than the one given to -(BOOL)connectTo...withTimeout(NSTimeInterval)timeout
+ * *NOTE* That records times timeout can be less than the value for the overall timeout.
  *
- * Defaults to 300ms.
+ * Defaults to 2s.
 **/
-@property (atomic, assign, readwrite) NSTimeInterval alternateAddressDelay;
+@property (atomic, assign, readwrite) int connectionAttemptTimeout;
 
 /**
  * User data allows you to associate arbitrary information with the socket.
@@ -1085,6 +1087,12 @@ typedef NS_ENUM(NSInteger, GCDAsyncSocketError) {
  * The host parameter will be an IP address, not a DNS name.
 **/
 - (void)socket:(GCDAsyncSocket *)sock didConnectToHost:(NSString *)host port:(uint16_t)port;
+
+/**
+ * Called when a socket fails to connect and there are multiple addresses for the given host.
+ * Return YES to allow using a failover address, the default is NO.
+ **/
+- (BOOL)socket:(GCDAsyncSocket *)sock shouldFailoverToAddressIndex:(NSUInteger)addressIndex withAddressTotal:(NSUInteger)addressTotal;
 
 /**
  * Called when a socket connects and is ready for reading and writing.

--- a/Tests/iOS/CocoaAsyncSocket.xcodeproj/project.pbxproj
+++ b/Tests/iOS/CocoaAsyncSocket.xcodeproj/project.pbxproj
@@ -289,6 +289,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -327,6 +328,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.chrisballinger.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 2.3;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/Tests/iOS/Podfile.lock
+++ b/Tests/iOS/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - CocoaAsyncSocket (7.5.0):
-    - CocoaAsyncSocket/GCD (= 7.5.0)
-  - CocoaAsyncSocket/GCD (7.5.0)
+  - CocoaAsyncSocket (7.5.1):
+    - CocoaAsyncSocket/GCD (= 7.5.1)
+  - CocoaAsyncSocket/GCD (7.5.1)
 
 DEPENDENCIES:
   - CocoaAsyncSocket (from `../../CocoaAsyncSocket.podspec`)
@@ -11,8 +11,8 @@ EXTERNAL SOURCES:
     :path: "../../CocoaAsyncSocket.podspec"
 
 SPEC CHECKSUMS:
-  CocoaAsyncSocket: 3baeb1ddd969f81cf9fca81053ae49ef2d1cbbfa
+  CocoaAsyncSocket: e0a7e93b2ffa411592ff87e58524fbbc9b95b4fa
 
 PODFILE CHECKSUM: 7ab0033c45d6145d209ac97a4d0f7905792ec3af
 
-COCOAPODS: 1.0.1
+COCOAPODS: 1.0.0


### PR DESCRIPTION
When a FQDN have multiple DNS A records, these can serve as failover addresses. E.g. if one fails, try another.

This pull request contains changes to implement opt-in failover. You can opt-in a with a delegate callback which is checked for each address prior to failing over.
