### PR TITLE
GCDAsyncSocket.startTLS has incorrect type specified in header file

### DIFF
--- a/Source/GCD/GCDAsyncSocket.h
+++ b/Source/GCD/GCDAsyncSocket.h
@@ -788,7 +788,7 @@ typedef NS_ENUM(NSInteger, GCDAsyncSocketError) {
  * 
  * You can also perform additional validation in socketDidSecure.
 **/
-- (void)startTLS:(nullable NSDictionary <NSString*,NSNumber*>*)tlsSettings;
+- (void)startTLS:(nullable NSDictionary <NSString*,NSObject*>*)tlsSettings;
 
 #pragma mark Advanced
 


### PR DESCRIPTION
In version 7.5.0 of CocoaAsyncSocket, this is the signature of the `startTLS` method in `GCDAsyncSocket.h:791`:

    - (void)startTLS:(nullable NSDictionary <NSString*,NSNumber*>*)tlsSettings;

However, many of the keys require values that are not a `NSNumber`, e.g. `GCDAsyncSocketSSLCipherSuites` (`NSArray` of `NSNumber`), `kCFStreamSSLCertificates` (`NSArray` of certificates).

Using this from Swift causes compiler errors (for which I don't know a work-around).

Solution is to change the signature to:

    - (void)startTLS:(nullable NSDictionary <NSString*,NSObject*>*)tlsSettings;

Please note that this is blocking for Swift developers, I don't know of a workaround. It's a very small change, a quick merge and release would be very much appreciated :)