### PR TITLE
Fixing small typo

### DIFF
--- a/Source/GCD/GCDAsyncSocket.h
+++ b/Source/GCD/GCDAsyncSocket.h
@@ -348,7 +348,7 @@ typedef NS_ENUM(NSInteger, GCDAsyncSocketError) {
  * Returns whether the socket is disconnected or connected.
  * 
  * A disconnected socket may be recycled.
- * That is, it can used again for connecting or listening.
+ * That is, it can be used again for connecting or listening.
  * 
  * If a socket is in the process of connecting, it may be neither disconnected nor connected.
 **/


### PR DESCRIPTION
In GCDAsyncSocket.h, here was small typo.

To satisfy English grammar,

**That is, it 'can used' again for connecting or listening.**
should be
**That is, it 'can be used' again for connecting or listening.**
