### PR TITLE
fixes #497: suppress self-deprecation warnings

### DIFF
--- a/Source/GCD/GCDAsyncSocket.m
+++ b/Source/GCD/GCDAsyncSocket.m
@@ -932,7 +932,7 @@ enum GCDAsyncSocketConfig
 	return [self initWithDelegate:aDelegate delegateQueue:dq socketQueue:NULL];
 }
 
-- (id)initWithDelegate:(id)aDelegate delegateQueue:(dispatch_queue_t)dq socketQueue:(dispatch_queue_t)sq
+- (id)initWithDelegate:(id<GCDAsyncSocketDelegate>)aDelegate delegateQueue:(dispatch_queue_t)dq socketQueue:(dispatch_queue_t)sq
 {
 	if((self = [super init]))
 	{

--- a/Source/RunLoop/AsyncSocket.m
+++ b/Source/RunLoop/AsyncSocket.m
@@ -668,7 +668,12 @@ static void MyCFWriteStreamCallback(CFWriteStreamRef stream, CFStreamEventType t
 #pragma mark -
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+
 @implementation AsyncSocket
+
+#pragma clang diagnostic pop
 
 - (id)init
 {
@@ -4249,7 +4254,10 @@ static void MyCFSocketCallback (CFSocketRef sref, CFSocketCallBackType type, CFD
 {
 	@autoreleasepool {
 	
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 		AsyncSocket *theSocket = (__bridge AsyncSocket *)pInfo;
+#pragma clang diagnostic pop
 		NSData *address = [(__bridge NSData *)inAddress copy];
 		
 		[theSocket doCFSocketCallback:type forSocket:sref withAddress:address withData:pData];
@@ -4265,7 +4273,10 @@ static void MyCFReadStreamCallback (CFReadStreamRef stream, CFStreamEventType ty
 {
 	@autoreleasepool {
 	
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 		AsyncSocket *theSocket = (__bridge AsyncSocket *)pInfo;
+#pragma clang diagnostic pop
 		[theSocket doCFReadStreamCallback:type forStream:stream];
 	
 	}
@@ -4279,7 +4290,10 @@ static void MyCFWriteStreamCallback (CFWriteStreamRef stream, CFStreamEventType 
 {
 	@autoreleasepool {
 	
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 		AsyncSocket *theSocket = (__bridge AsyncSocket *)pInfo;
+#pragma clang diagnostic pop
 		[theSocket doCFWriteStreamCallback:type forStream:stream];
 	
 	}

--- a/Source/RunLoop/AsyncUdpSocket.m
+++ b/Source/RunLoop/AsyncUdpSocket.m
@@ -192,7 +192,12 @@ static void MyCFSocketCallback(CFSocketRef, CFSocketCallBackType, CFDataRef, con
 #pragma mark -
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+
 @implementation AsyncUdpSocket
+
+#pragma clang diagnostic pop
 
 - (id)initWithDelegate:(id)delegate userData:(long)userData enableIPv4:(BOOL)enableIPv4 enableIPv6:(BOOL)enableIPv6
 {
@@ -2303,8 +2308,11 @@ static void MyCFSocketCallback(CFSocketRef, CFSocketCallBackType, CFDataRef, con
 static void MyCFSocketCallback(CFSocketRef sref, CFSocketCallBackType type, CFDataRef address, const void *pData, void *pInfo)
 {
 	@autoreleasepool {
-	
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 		AsyncUdpSocket *theSocket = (__bridge AsyncUdpSocket *)pInfo;
+#pragma clang diagnostic pop
 		[theSocket doCFSocketCallback:type forSocket:sref withAddress:(__bridge NSData *)address withData:pData];
 	
 	}


### PR DESCRIPTION
Use pragmas to suppress self-deprecation warnings in the implementations of AsyncSocket and AsyncUdpSocket.