### PR TITLE
Removed the copyright notice from the CocoaAsyncSocket.h file.

### DIFF
--- a/Source/CocoaAsyncSocket.h
+++ b/Source/CocoaAsyncSocket.h
@@ -1,9 +1,8 @@
-//
+﻿//
 //  CocoaAsyncSocket.h
 //  CocoaAsyncSocket
 //
 //  Created by Derek Clarkson on 10/08/2015.
-//  Copyright © 2015 Robbie Hanson. All rights reserved.
 //
 
 @import Foundation;


### PR DESCRIPTION
The Public Domain License applies to works that "are no longer in
copyright term", or "were never protected by copyright law". Removing this
copyright effectively allows the library to be fully under the Public
Domain License.