### PR TITLE
Add common chunked response terminator

### DIFF
--- a/Source/GCD/GCDAsyncSocket.h
+++ b/Source/GCD/GCDAsyncSocket.h
@@ -1034,10 +1034,11 @@ typedef NS_ENUM(NSInteger, GCDAsyncSocketError) {
 /**
  * A few common line separators, for use with the readDataToData:... methods.
 **/
-+ (NSData *)CRLFData;   // 0x0D0A
-+ (NSData *)CRData;     // 0x0D
-+ (NSData *)LFData;     // 0x0A
-+ (NSData *)ZeroData;   // 0x00
++ (NSData *)CRLFData;       // 0x0D0A
++ (NSData *)DoubleCRLFData; // 0x0D0A0D0A
++ (NSData *)CRData;         // 0x0D
++ (NSData *)LFData;         // 0x0A
++ (NSData *)ZeroData;       // 0x00
 
 @end
 

--- a/Source/GCD/GCDAsyncSocket.m
+++ b/Source/GCD/GCDAsyncSocket.m
@@ -8347,6 +8347,11 @@ static void CFWriteStreamCallback (CFWriteStreamRef stream, CFStreamEventType ty
 	return [NSData dataWithBytes:"\x0D\x0A" length:2];
 }
 
++ (NSData *)DoubleCRLFData
+{
+	return [NSData dataWithBytes:"\x0D\x0A\x0D\x0A" length:4];
+}
+
 + (NSData *)CRData
 {
 	return [NSData dataWithBytes:"\x0D" length:1];


### PR DESCRIPTION
Chunked HTTP responses typically contain
"Double CRLF" terminator which is to be
used in readDataToData: methods.

See  https://en.wikipedia.org/wiki/Chunked_transfer_encoding#Example for details.