### PR TITLE
Fix issues #222 and #535. Enlarge the maximum size of UDP packet.

### DIFF
--- a/Source/GCD/GCDAsyncUdpSocket.h
+++ b/Source/GCD/GCDAsyncUdpSocket.h
@@ -252,6 +252,21 @@ typedef BOOL (^GCDAsyncUdpSocketSendFilterBlock)(NSData *data, NSData *address, 
 - (void)setMaxReceiveIPv6BufferSize:(uint32_t)max;
 
 /**
+ * Gets/Sets the maximum size of the buffer that will be allocated for send operations.
+ * The default maximum size is 65535 bytes.
+ * 
+ * Given that a typical link MTU is 1500 bytes, a large UDP datagram will have to be 
+ * fragmented, and that’s both expensive and risky (if one fragment goes missing, the
+ * entire datagram is lost).  You are much better off sending a large number of smaller
+ * UDP datagrams, preferably using a path MTU algorithm to avoid fragmentation.
+ *
+ * You must set it before the sockt is created otherwise it won't work.
+ *
+ **/
+- (uint32_t)maxSendBufferSize;
+- (void)setMaxSendBufferSize:(uint16_t)max;
+
+/**
  * User data allows you to associate arbitrary information with the socket.
  * This data is not used internally in any way.
 **/

--- a/Source/GCD/GCDAsyncUdpSocket.h
+++ b/Source/GCD/GCDAsyncUdpSocket.h
@@ -231,7 +231,7 @@ typedef BOOL (^GCDAsyncUdpSocketSendFilterBlock)(NSData *data, NSData *address, 
 
 /**
  * Gets/Sets the maximum size of the buffer that will be allocated for receive operations.
- * The default maximum size is 9216 bytes.
+ * The default maximum size is 65535 bytes.
  * 
  * The theoretical maximum size of any IPv4 UDP packet is UINT16_MAX = 65535.
  * The theoretical maximum size of any IPv6 UDP packet is UINT32_MAX = 4294967295.
@@ -263,7 +263,7 @@ typedef BOOL (^GCDAsyncUdpSocketSendFilterBlock)(NSData *data, NSData *address, 
  * You must set it before the sockt is created otherwise it won't work.
  *
  **/
-- (uint32_t)maxSendBufferSize;
+- (uint16_t)maxSendBufferSize;
 - (void)setMaxSendBufferSize:(uint16_t)max;
 
 /**

--- a/Source/GCD/GCDAsyncUdpSocket.m
+++ b/Source/GCD/GCDAsyncUdpSocket.m
@@ -883,9 +883,9 @@ enum GCDAsyncUdpSocketConfig
         dispatch_async(socketQueue, block);
 }
 
-- (uint32_t)maxSendBufferSize
+- (uint16_t)maxSendBufferSize
 {
-    __block uint32_t result = 0;
+    __block uint16_t result = 0;
     
     dispatch_block_t block = ^{
         

--- a/Source/GCD/GCDAsyncUdpSocket.m
+++ b/Source/GCD/GCDAsyncUdpSocket.m
@@ -378,7 +378,7 @@ enum GCDAsyncUdpSocketConfig
 		max4ReceiveSize = 65535;
 		max6ReceiveSize = 65535;
 		
-        maxSendSize = 9216;
+        maxSendSize = 65535;
         
 		socket4FD = SOCKET_NULL;
 		socket6FD = SOCKET_NULL;

--- a/Tests/Shared/GCDAsyncUdpSocketConnectionTests.m
+++ b/Tests/Shared/GCDAsyncUdpSocketConnectionTests.m
@@ -1,0 +1,159 @@
+//
+//  GCDAsyncUdpSocketConnectionTests.m
+//  CocoaAsyncSocket
+//
+//  Created by 李博文 on 2017/3/25.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+@import CocoaAsyncSocket;
+
+@interface GCDAsyncUdpSocketConnectionTests : XCTestCase<GCDAsyncUdpSocketDelegate>
+@property (nonatomic) uint16_t portNumber;
+@property (nonatomic, strong) GCDAsyncUdpSocket *clientSocket;
+@property (nonatomic, strong) GCDAsyncUdpSocket *serverSocket;
+
+@property (nonatomic, strong) NSMutableData *testData;
+@property (nonatomic, assign) NSInteger sendDataLength;
+
+@property (nonatomic, strong) XCTestExpectation *expectation;
+
+@end
+
+@implementation GCDAsyncUdpSocketConnectionTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+    self.portNumber = [self randomValidPort];
+    self.clientSocket = [[GCDAsyncUdpSocket alloc] initWithDelegate:self delegateQueue:dispatch_get_main_queue()];
+    
+    self.serverSocket = [[GCDAsyncUdpSocket alloc] initWithDelegate:self delegateQueue:dispatch_get_main_queue()];
+    
+    self.testData = [NSMutableData data];
+    
+    NSData* data = [@"test-data-" dataUsingEncoding:NSUTF8StringEncoding];
+    
+    for (int i = 0; i < 7000; i ++)
+    {
+        [self.testData appendData:data];
+    }
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+    
+    self.clientSocket = nil;
+    self.serverSocket = nil;
+    
+    self.testData = nil;
+}
+
+- (uint16_t) randomValidPort {
+    uint16_t minPort = 1024;
+    uint16_t maxPort = UINT16_MAX;
+    return minPort + arc4random_uniform(maxPort - minPort + 1);
+}
+
+- (uint16_t) randomLengthOfLargePacket {
+    uint16_t minLength = 9217;
+    uint16_t maxLength = UINT16_MAX;
+    return minLength + arc4random_uniform(maxLength - minLength + 1);
+}
+
+- (uint32_t) randomLengthOfInvaildPacket {
+    uint32_t minLength = 65536;
+    uint32_t maxLength = UINT16_MAX;
+    return minLength + arc4random_uniform(maxLength - minLength + 1);
+}
+
+- (void)testSendBoardcastWithMicroPacket
+{
+    NSError * error = nil;
+    BOOL success = NO;
+    success = [self.serverSocket bindToPort:self.portNumber error:&error] && [self.serverSocket beginReceiving:&error];
+    XCTAssertTrue(success, @"UDP Server failed setting up socket on port %d %@", self.portNumber, error);
+    
+    NSData * sendData = [self.testData subdataWithRange:NSMakeRange(0, arc4random_uniform(9217))];
+    NSLog(@"DATA Length is %ld",sendData.length);
+    self.sendDataLength = sendData.length;
+    
+    [self.clientSocket sendData:sendData toHost:@"127.0.0.1" port:self.portNumber withTimeout:30 tag:0];
+    
+    self.expectation = [self expectationWithDescription:@"Test Sending/Receving Micro Packet"];
+    [self waitForExpectationsWithTimeout:30 handler:^(NSError *error) {
+        if (error) {
+            NSLog(@"Error establishing test sending/receving micro packet");
+        }
+    }];
+}
+
+- (void)testSendBoardcastWithLargePacket
+{
+    NSError * error = nil;
+    BOOL success = NO;
+    success = [self.serverSocket bindToPort:self.portNumber error:&error] && [self.serverSocket beginReceiving:&error];
+    XCTAssertTrue(success, @"UDP Server failed setting up socket on port %d %@", self.portNumber, error);
+    
+    NSData * sendData = [self.testData subdataWithRange:NSMakeRange(0, [self randomLengthOfLargePacket])];
+    NSLog(@"DATA Length is %ld",sendData.length);
+    self.sendDataLength = sendData.length;
+    [self.clientSocket sendData:sendData toHost:@"127.0.0.1" port:self.portNumber withTimeout:30 tag:0];
+    
+    self.expectation = [self expectationWithDescription:@"Test Sending/Receving Large Packet"];
+    [self waitForExpectationsWithTimeout:30 handler:^(NSError *error) {
+        if (error) {
+            NSLog(@"Error establishing test sending/receving large Packet");
+        }
+    }];
+}
+
+- (void)testSendBoardcastWithInvaildPacket
+{
+    NSError * error = nil;
+    BOOL success = NO;
+    success = [self.serverSocket bindToPort:self.portNumber error:&error] && [self.serverSocket beginReceiving:&error];
+    XCTAssertTrue(success, @"UDP Server failed setting up socket on port %d %@", self.portNumber, error);
+    
+    NSData * sendData = [self.testData subdataWithRange:NSMakeRange(0, [self randomLengthOfLargePacket])];
+    NSLog(@"DATA Length is %ld",sendData.length);
+    self.sendDataLength = sendData.length;
+    [self.clientSocket sendData:sendData toHost:@"127.0.0.1" port:self.portNumber withTimeout:30 tag:0];
+    
+    self.expectation = [self expectationWithDescription:@"Test Sending/Receving Invaild Packet"];
+    [self waitForExpectationsWithTimeout:30 handler:^(NSError *error) {
+        if (error) {
+            NSLog(@"Error establishing test sending/receving invaild packet");
+        }
+    }];
+}
+
+#pragma mark GCDAsyncUdpSocketDelegate methods
+/**
+ * Called when the datagram with the given tag has been sent.
+ **/
+- (void)udpSocket:(GCDAsyncUdpSocket *)sock didSendDataWithTag:(long)tag
+{
+    NSLog(@"send data");
+}
+
+
+- (void)udpSocketDidClose:(GCDAsyncUdpSocket *)sock withError:(NSError  * _Nullable)error
+{
+    NSLog(@"closr error is %@",error);
+    [self.expectation fulfill];
+}
+
+- (void)udpSocket:(GCDAsyncUdpSocket *)sock didReceiveData:(NSData *)data
+      fromAddress:(NSData *)address
+withFilterContext:(nullable id)filterContext
+{
+    XCTAssertTrue(data.length == self.sendDataLength, @"UDP packet is truncated on port %d", self.portNumber);
+    [self.expectation fulfill];
+}
+
+\
+@end


### PR DESCRIPTION
Hi!

This branch fix issues #222( Don't trust GCD to give accurate UDP packet sizes) and #535(GCDAsyncUDPSocket can not send data when data is greater than 9K). The reason is that the default maximum size of the UDP buffer in iOS is 9216 bytes. So they can not send data if the size of data is grater than 9216 or packets can be silently truncated without any log.

I enlarge the maximum size of UDP packet by function setsockopt and change the value of max4ReceiveSize/max6ReceiveSize.

I test my changes and it works fine!