### PR TITLE
Added bundle ID to Mac framework info dictionary.

### DIFF
--- a/CocoaAsyncSocket.xcodeproj/project.pbxproj
+++ b/CocoaAsyncSocket.xcodeproj/project.pbxproj
@@ -507,6 +507,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = com.robbiehanson.CocoaAsyncSocket;
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -528,6 +529,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = com.robbiehanson.CocoaAsyncSocket;
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
My apologies in advance: I'm not super familiar with GitHub pull requests.

I'm building a Mac app that we're putting on the App Store and got an error from Xcode when going to upload my build artifacts as a result of the bundle identifier being missing in the Mac framework. The fix is easy--just add the bundle ID. I thought it'd be worth sending upstream in case other people run into it.

I've uploaded a screenshot of the error message here:
http://i.imgur.com/jr51LhR.jpg