### PR TITLE
delete redundant method call in doConnectTimeout method

### DIFF
--- a/Source/GCD/GCDAsyncSocket.m
+++ b/Source/GCD/GCDAsyncSocket.m
@@ -3143,7 +3143,6 @@ enum GCDAsyncSocketConfig
 {
 	LogTrace();
 	
-	[self endConnectTimeout];
 	[self closeWithError:[self connectTimeoutError]];
 }
 


### PR DESCRIPTION
"-doConnectTimeout" method call two methods, "-endConnectTimeout" and "-closeWithError:".  "-closeWithError:" method  call "-endConnectTimeout" too. It is redundant.