### PR TITLE
Refactor read tests and scaffolding

### DIFF
--- a/Source/GCD/GCDAsyncSocket.m
+++ b/Source/GCD/GCDAsyncSocket.m
@@ -441,8 +441,7 @@ enum GCDAsyncSocketConfig
 	if (readLength > 0)
 	{
 		// Read a specific length of data
-		
-		result = MIN(defaultValue, (readLength - bytesDone));
+		result = readLength - bytesDone;
 		
 		// There is no need to prebuffer since we know exactly how much data we need to read.
 		// Even if the buffer isn't currently big enough to fit this amount of data,

--- a/Tests/Shared/GCDAsyncSocketReadTests.swift
+++ b/Tests/Shared/GCDAsyncSocketReadTests.swift
@@ -5,15 +5,22 @@ class GCDAsyncSocketReadTests: XCTestCase {
 	func test_whenBytesAvailableIsLessThanReadLength_readDoesNotTimeout() {
 		TestSocket.waiterDelegate = self
 
-		let (client, server) = TestSocket.createSecurePair()
+		let server = TestServer()
+		let (client, accepted) = server.createSecurePair()
+
+		defer {
+			client.close()
+			accepted.close()
+			server.close()
+		}
 
 		// Write once to fire the readSource on the client, also causing the
 		// readSource to be suspended.
-		server.write(bytes: 1024 * 50)
+		accepted.write(bytes: 1024 * 50)
 
 		// Write a second time to ensure there is more on the socket than in the
 		// "estimatedBytesAvailable + 16kb" upperbound in our SSLRead.
-		server.write(bytes: 1024 * 50)
+		accepted.write(bytes: 1024 * 50)
 
 		// Ensure our socket is not disconnected when we attempt to read everything in
 		client.onDisconnect = {

--- a/Tests/Shared/TestServer.swift
+++ b/Tests/Shared/TestServer.swift
@@ -47,51 +47,62 @@ class TestServer: NSObject {
 		}
 	}()
 
+	private static func randomValidPort() -> UInt16 {
+		let minPort = UInt32(1024)
+		let maxPort = UInt32(UINT16_MAX)
+		let value = maxPort - minPort + 1
+
+		return UInt16(minPort + arc4random_uniform(value))
+	}
+
+	// MARK: Convenience Callbacks
+
 	typealias Callback = TestSocket.Callback
 
-	var onAccept: Callback = {}
+	var onAccept: Callback
+	var onDisconnect: Callback
 
-	var port: UInt16 = 1234
+	let port: UInt16 = TestServer.randomValidPort()
+	let queue = DispatchQueue(label: "com.asyncSocket.TestServerDelegate")
+	let socket: GCDAsyncSocket
 
-	var lastAcceptedSocket: GCDAsyncSocket? = nil
+	var lastAcceptedSocket: TestSocket? = nil
 
-	lazy var socket: GCDAsyncSocket = { [weak self] in
-		let label = "com.asyncSocket.TestServerDelegate"
-		let queue = DispatchQueue(label: label)
+	override init() {
+		self.socket = GCDAsyncSocket()
+		super.init()
 
-		return GCDAsyncSocket(delegate: self, delegateQueue: queue)
-		}()
+		self.socket.delegate = self
+		self.socket.delegateQueue = self.queue
+	}
 
-	func accept() -> TestSocket {
-		let waiter = XCTWaiter(delegate: TestSocket.waiterDelegate)
-		let didAccept = XCTestExpectation(description: "Accepted socket")
-
-		self.onAccept = {
-			didAccept.fulfill()
-		}
-
+	func accept() {
 		do {
 			try self.socket.accept(onPort: self.port)
 		}
 		catch {
 			fatalError("Failed to accept on port \(self.port): \(error)")
 		}
-
-		waiter.wait(for: [didAccept], timeout: 0.1)
-
-		guard let accepted = self.lastAcceptedSocket else {
-			fatalError("No socket connected")
-		}
-
-		let socket = TestSocket(socket: accepted)
-		accepted.delegate = socket
-		accepted.delegateQueue = socket.queue
-
-		return socket
 	}
 
-	deinit {
-		self.socket.disconnect()
+	func close() {
+		let waiter = XCTWaiter(delegate: TestSocket.waiterDelegate)
+		let didDisconnect = XCTestExpectation(description: "Server disconnected")
+
+		self.queue.async {
+			guard self.socket.isConnected else {
+				didDisconnect.fulfill()
+				return
+			}
+
+			self.onDisconnect = {
+				didDisconnect.fulfill()
+			}
+
+			self.socket.disconnect()
+		}
+
+		waiter.wait(for: [didDisconnect], timeout: 0.2)
 	}
 }
 
@@ -100,9 +111,66 @@ class TestServer: NSObject {
 extension TestServer: GCDAsyncSocketDelegate {
 
 	func socket(_ sock: GCDAsyncSocket, didAcceptNewSocket newSocket: GCDAsyncSocket) {
-		self.lastAcceptedSocket = newSocket
+		self.lastAcceptedSocket = TestSocket(socket: newSocket)
 
-		self.onAccept()
-		self.onAccept = {}
+		self.onAccept?()
+		self.onAccept = nil
+	}
+
+	func socketDidDisconnect(_ sock: GCDAsyncSocket, withError err: Error?) {
+		self.onDisconnect?()
+		self.onDisconnect = nil
+	}
+}
+
+// MARK: Factory
+
+extension TestServer {
+
+	func createPair() -> (client: TestSocket, accepted: TestSocket) {
+		let waiter = XCTWaiter(delegate: TestSocket.waiterDelegate)
+		let didConnect = XCTestExpectation(description: "Pair connected")
+		didConnect.expectedFulfillmentCount = 2
+
+		let client = TestSocket()
+
+		self.onAccept = {
+			didConnect.fulfill()
+		}
+
+		client.onConnect = {
+			didConnect.fulfill()
+		}
+
+		self.accept()
+		client.connect(on: self.port)
+
+		let result = waiter.wait(for: [didConnect], timeout: 2.0)
+
+		guard let accepted = self.lastAcceptedSocket else {
+			fatalError("No socket connected on \(self.port)")
+		}
+
+		return (client, accepted)
+	}
+
+	func createSecurePair() -> (client: TestSocket, accepted: TestSocket) {
+		let (client, accepted) = self.createPair()
+
+		let waiter = XCTWaiter(delegate: TestSocket.waiterDelegate)
+		let didSecure = XCTestExpectation(description: "Socket did secure")
+		didSecure.expectedFulfillmentCount = 2
+
+		accepted.startTLS(as: .server) {
+			didSecure.fulfill()
+		}
+
+		client.startTLS(as: .client) {
+			didSecure.fulfill()
+		}
+
+		waiter.wait(for: [didSecure], timeout: 0.2)
+
+		return (client, accepted)
 	}
 }


### PR DESCRIPTION
Key changes are:
- Include the the server handle in the tests along with the client and accepted handles
- Explicitly close sockets in tests instead of in deinit
- Use random port instead of fixed `1234`

The goal of these changes was to get the newly added read test to run
in a loop of 1000 iterations. I encountered two issues with this:

1. `dispatch_source_cancel` is asynchronous which means that we can call
`socketDidDisconnect` before the file descriptor is actually released.
This causes issues because we immediately try to connect to the same
port after `socketDidDisconnect` is called. This can cause "Address
already in use" errors. We may want to see if we can wait until our
source cancellation callback has been executed before we inform the
delegate that we are disconnected. I wasn't going to make that change
here, so I worked around the issue by using a random port for each
iteration.

2. Sometimes we run into an issue where SSLRead returns errSSLWouldBlock
and we haven't yet read all of the data. Even though the readSource is
not suspended, since all of the data has already been written, the
readSource won't fire and we can still end up in a hung state. I don't
really know the best way to handle this one. I didn't put any
workaround in place because it seems out of scope for this.

The bottom line is that after 20 or so iterations you will run into the
second issue. Until that is fixed these tests can run in a large loop.