### PR TITLE
Potentially leaking file descriptor that may lead to fatal crash

### DIFF
--- a/Source/GCD/GCDAsyncSocket.m
+++ b/Source/GCD/GCDAsyncSocket.m
@@ -1919,15 +1919,15 @@ enum GCDAsyncSocketConfig
         dispatch_source_set_cancel_handler(self->acceptUNSource, ^{
 			
 #if NEEDS_DISPATCH_RETAIN_RELEASE
-			LogVerbose(@"dispatch_release(accept4Source)");
+			LogVerbose(@"dispatch_release(acceptUNSource)");
 			dispatch_release(acceptSource);
 #endif
 			
-			LogVerbose(@"close(socket4FD)");
+			LogVerbose(@"close(socketUN)");
 			close(socketFD);
 		});
 		
-		LogVerbose(@"dispatch_resume(accept4Source)");
+		LogVerbose(@"dispatch_resume(acceptUNSource)");
         dispatch_resume(self->acceptUNSource);
 		
         self->flags |= kSocketStarted;

--- a/Source/GCD/GCDAsyncSocket.m
+++ b/Source/GCD/GCDAsyncSocket.m
@@ -1625,6 +1625,7 @@ enum GCDAsyncSocketConfig
 				{
 					LogVerbose(@"close(socket4FD)");
                     close(self->socket4FD);
+                    self->socket4FD = SOCKET_NULL;
 				}
 				
 				return_from_block;


### PR DESCRIPTION
GCDAsyncSocket.m:1620, if createSocket fails for any reason and assigns SOCKET_NULL to socket6FD, and if socket4FD was valid, socket4FD will then be closed but without being set to SOCKET_NULL, leaving it to be closed once again later during dealloc -> closeWithError:... 

If any other part of the system has acquired that file descriptor in the meantime, the application can become unstable and/or crash, often with EXC_GUARD if any other part of the system has acquired and put a guard on it.

I see this error daily in about 0.02% of my user sessions.