### PR TITLE
Fix build for SPM generated Xcode project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,6 @@ script:
   - bash Tests/test-all.sh
   - swift build
   - swift test
+  - swift package generate-xcodeproj --output spm-generated.xcodeproj && xcodebuild -project spm-generated.xcodeproj && rm -rf spm-generated.xcodeproj
   - bundle exec pod lib lint
   - carthage build --no-skip-current && for platform in Mac iOS tvOS; do test -d Carthage/Build/${platform}/CocoaAsyncSocket.framework || exit 1; done

--- a/CocoaAsyncSocket.xcodeproj/project.pbxproj
+++ b/CocoaAsyncSocket.xcodeproj/project.pbxproj
@@ -25,7 +25,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		6C55C7D11B7838B1006A7440 /* CocoaAsyncSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CocoaAsyncSocket.h; path = Source/CocoaAsyncSocket.h; sourceTree = SOURCE_ROOT; };
+		6C55C7D11B7838B1006A7440 /* CocoaAsyncSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CocoaAsyncSocket.h; path = Source/GCD/CocoaAsyncSocket.h; sourceTree = SOURCE_ROOT; };
 		6CD990101B77868C0011A685 /* CocoaAsyncSocket.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CocoaAsyncSocket.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6CD990151B77868C0011A685 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = Info.plist; path = Source/Info.plist; sourceTree = "<group>"; };
 		6CD9902C1B7789680011A685 /* GCDAsyncSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GCDAsyncSocket.h; path = Source/GCD/GCDAsyncSocket.h; sourceTree = SOURCE_ROOT; };
@@ -84,7 +84,6 @@
 			children = (
 				6CD9902A1B7789220011A685 /* GCD */,
 				6CD990151B77868C0011A685 /* Info.plist */,
-				6C55C7D11B7838B1006A7440 /* CocoaAsyncSocket.h */,
 			);
 			path = CocoaAsyncSocket;
 			sourceTree = "<group>";
@@ -92,6 +91,7 @@
 		6CD9902A1B7789220011A685 /* GCD */ = {
 			isa = PBXGroup;
 			children = (
+				6C55C7D11B7838B1006A7440 /* CocoaAsyncSocket.h */,
 				6CD9902C1B7789680011A685 /* GCDAsyncSocket.h */,
 				6CD9902D1B7789680011A685 /* GCDAsyncSocket.m */,
 				6CD9902E1B7789680011A685 /* GCDAsyncUdpSocket.h */,

--- a/Source/GCD/CocoaAsyncSocket.h
+++ b/Source/GCD/CocoaAsyncSocket.h
@@ -14,5 +14,9 @@ FOUNDATION_EXPORT double cocoaAsyncSocketVersionNumber;
 //! Project version string for CocoaAsyncSocket.
 FOUNDATION_EXPORT const unsigned char cocoaAsyncSocketVersionString[];
 
-#import <CocoaAsyncSocket/GCDAsyncSocket.h>
-#import <CocoaAsyncSocket/GCDAsyncUdpSocket.h>
+#ifndef _COCOA_ASYNC_SOCKET_
+    #define _COCOA_ASYNC_SOCKET_
+
+    #import "GCDAsyncSocket.h"
+    #import "GCDAsyncUdpSocket.h"
+#endif


### PR DESCRIPTION
## Overview
This fixes the issue described in https://github.com/robbiehanson/CocoaAsyncSocket/issues/727.

Before this change, the Xcode project generated by the Swift Package Manager failed to build.

```zsh
% swift package generate-xcodeproj --output spm-generated.xcodeproj
% xcodebuild -project spm-generated.xcodeproj
```

The generated project failed to build because `CLANG_ENABLE_MODULES` was set to `NO`.

We can have the generated project set `CLANG_ENABLE_MODULES` to `YES` by [including the umbrella header](https://bugs.swift.org/browse/SR-7531?focusedCommentId=36686&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-36686) in the `publicHeadersPath`.

Thanks for considering these changes and for supporting this library.

– Will

cc @RockLobster for any input since this is a follow on to https://github.com/robbiehanson/CocoaAsyncSocket/pull/706.

## Detailed Changes
- Move umbrella header so that it’s included in the package’s `publicHeadersPath`
    - `Source/CocoaAsyncSocket.h` → `Source/GCD/CocoaAsyncSocket.h`
- Use local imports for umbrella header to fix `swift test` after moving the umbrella header

See [AFNetworking](https://github.com/AFNetworking/AFNetworking) for a similar [folder structure](https://github.com/AFNetworking/AFNetworking/tree/master/AFNetworking), [umbrella header format](https://github.com/AFNetworking/AFNetworking/blob/master/AFNetworking/AFNetworking.h), and [`publicHeadersPath` configuration](https://github.com/AFNetworking/AFNetworking/blob/master/Package.swift#L37)

## Tests
- Updated Travis to test SPM's generated Xcode project
- Manually tested these changes are compatible with CocoaPods and Carthage
- [All automated tests are passing](https://travis-ci.com/github/wlisac/CocoaAsyncSocket/builds/183027326)