### PR TITLE
Fix Xcode 12.5 Warning: Write to autoreleasing out parameter ...

### DIFF
--- a/Source/GCD/GCDAsyncSocket.m
+++ b/Source/GCD/GCDAsyncSocket.m
@@ -1077,6 +1077,7 @@ enum GCDAsyncSocketConfig
 + (nullable instancetype)socketFromConnectedSocketFD:(int)socketFD delegate:(nullable id<GCDAsyncSocketDelegate>)aDelegate delegateQueue:(nullable dispatch_queue_t)dq socketQueue:(nullable dispatch_queue_t)sq error:(NSError* __autoreleasing *)error
 {
   __block BOOL errorOccured = NO;
+  __block NSError *thisError = nil;
   
   GCDAsyncSocket *socket = [[[self class] alloc] initWithDelegate:aDelegate delegateQueue:dq socketQueue:sq];
   
@@ -1093,8 +1094,7 @@ enum GCDAsyncSocketConfig
       NSDictionary *userInfo = @{NSLocalizedDescriptionKey : errMsg};
 
       errorOccured = YES;
-      if (error)
-        *error = [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketOtherError userInfo:userInfo];
+      thisError = [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketOtherError userInfo:userInfo];
       return;
     }
     
@@ -1115,14 +1115,17 @@ enum GCDAsyncSocketConfig
       NSDictionary *userInfo = @{NSLocalizedDescriptionKey : errMsg};
       
       errorOccured = YES;
-      if (error)
-        *error = [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketOtherError userInfo:userInfo];
+      thisError = [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketOtherError userInfo:userInfo];
       return;
     }
     
     socket->flags = kSocketStarted;
     [socket didConnect:socket->stateIndex];
   }});
+  
+  if (error && thisError) {
+    *error = thisError;
+  }
   
   return errorOccured? nil: socket;
 }


### PR DESCRIPTION
Fix for XCode 12.5 Warnings.
At two places the next warning was shown: "Write to autoreleasing out parameter inside locally-scoped autorelease pool; consider writing first to a strong local variable declared outside of the autorelease pool."
Solution: Implemented recommendation.