### PR TITLE
Add code to check if thread or runloop is nil

### DIFF
--- a/Source/GCD/GCDAsyncSocket.m
+++ b/Source/GCD/GCDAsyncSocket.m
@@ -7683,6 +7683,11 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 	
 	NSThread *currentThread = [NSThread currentThread];
 	NSRunLoop *currentRunLoop = [NSRunLoop currentRunLoop];
+
+      if (currentThread == nil || currentRunLoop == nil)
+      {
+          return;
+      }
 	
 	BOOL isCancelled = [currentThread isCancelled];
 	


### PR DESCRIPTION
There are occasional crashes on the 7689th line.
`while (!isCancelled && [currentRunLoop runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]])`

I could see that a crash occurs when `STOMPClient` instance is released from memory, which might lead to `currentThread` and `currentRunLoop` becoming nil. 
![스크린샷 2021-11-11 오후 10 53 56](https://user-images.githubusercontent.com/48151382/141610159-d7db0c9c-39f5-481c-8dc4-748cef82773b.png)

Therefore, I request that code be added to check whether `currentThread` and `currentRunLoop` are nil before the while statement.