### PR TITLE
Enable manually verifying client side authentication

### DIFF
--- a/Source/GCD/GCDAsyncSocket.h
+++ b/Source/GCD/GCDAsyncSocket.h
@@ -30,6 +30,7 @@ extern NSString *const GCDAsyncSocketQueueName;
 extern NSString *const GCDAsyncSocketThreadName;
 
 extern NSString *const GCDAsyncSocketManuallyEvaluateTrust;
+extern NSString *const GCDAsyncSocketSSLClientSideAuthenticate;
 #if TARGET_OS_IPHONE
 extern NSString *const GCDAsyncSocketUseCFStreamForTLS;
 #endif

--- a/Source/GCD/GCDAsyncSocket.h
+++ b/Source/GCD/GCDAsyncSocket.h
@@ -734,6 +734,14 @@ typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
  *     This is optional for iOS. If not supplied, a NO value is the default.
  *     This is not needed for Mac OS X, and the value is ignored.
  *
+ * - GCDAsyncSocketSSLClientSideAuthenticate
+ *     The value must be of type NSNumber, encapsulating a SSLAuthenticate value.
+ *     If you set GCDAsyncSocketManuallyEvaluateTrust and kCFStreamSSLIsServer
+ *     both to be true, you must also set this value to a SSLAuthenticate
+ *     that's not kNeverAuthenticate.
+ *     See Apple's documentation for SSLSetClientSideAuthenticate.
+ *     See also the SSLAuthenticate typedef.
+ *
  * - GCDAsyncSocketSSLPeerID
  *     The value must be of type NSData.
  *     You must set this value if you want to use TLS session resumption.

--- a/Source/GCD/GCDAsyncSocket.m
+++ b/Source/GCD/GCDAsyncSocket.m
@@ -6913,15 +6913,27 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 	{
 		if (isServer)
 		{
-			[self closeWithError:[self otherError:@"Manual trust validation is not supported for server sockets"]];
-			return;
+			status = SSLSetClientSideAuthenticate(sslContext, kTryAuthenticate);
+			if (status != noErr)
+			{
+				[self closeWithError:[self otherError:@"Error in SSLSetClientSideAuthenticate"]];
+				return;
+			}
+			status = SSLSetSessionOption(sslContext, kSSLSessionOptionBreakOnClientAuth, true);
+			if (status != noErr)
+			{
+				[self closeWithError:[self otherError:@"Error in SSLSetSessionOption"]];
+				return;
+			}
 		}
-		
-		status = SSLSetSessionOption(sslContext, kSSLSessionOptionBreakOnServerAuth, true);
-		if (status != noErr)
+		else
 		{
-			[self closeWithError:[self otherError:@"Error in SSLSetSessionOption"]];
-			return;
+			status = SSLSetSessionOption(sslContext, kSSLSessionOptionBreakOnServerAuth, true);
+			if (status != noErr)
+			{
+				[self closeWithError:[self otherError:@"Error in SSLSetSessionOption"]];
+				return;
+			}
 		}
 		
 		#if !TARGET_OS_IPHONE && (__MAC_OS_X_VERSION_MIN_REQUIRED < 1080)

--- a/Tests/Shared/Swift/ClientSideAuthenticateTests.swift
+++ b/Tests/Shared/Swift/ClientSideAuthenticateTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+import CocoaAsyncSocket
+
+class ClientSideAuthenticateTests: XCTestCase {
+    var server: TestServer!
+    var client: TestSocket!
+    var accepted: TestSocket!
+    
+    override func setUp() {
+        server = TestServer()
+        (client, accepted) = server.createPair()
+    }
+    
+    override func tearDown() {
+        client.close()
+        accepted.close()
+        server.close()
+    }
+    
+    func testAlwaysAuthenticateClient() {
+        let waiter = XCTWaiter(delegate: TestSocket.waiterDelegate)
+        let didSecure = XCTestExpectation(description: "Socket did secure")
+        didSecure.expectedFulfillmentCount = 2
+        let didReceiveTrust = XCTestExpectation(description: "Socket did receive trust")
+
+        accepted.onReceiveTrust = { _ in
+            didReceiveTrust.fulfill()
+            return true
+        }
+        accepted.startTLS(as: .server, additionalSettings: [
+            GCDAsyncSocketManuallyEvaluateTrust: NSNumber(value: true),
+            GCDAsyncSocketSSLClientSideAuthenticate: NSNumber(value: SSLAuthenticate.alwaysAuthenticate.rawValue),
+        ]) {
+            didSecure.fulfill()
+        }
+
+        client.startTLS(as: .client) {
+            didSecure.fulfill()
+        }
+
+        waiter.wait(for: [didReceiveTrust, didSecure], timeout: TestSocket.waiterTimeout)
+    }
+    
+    func testTryAuthenticateClient() {
+        let waiter = XCTWaiter(delegate: TestSocket.waiterDelegate)
+        let didSecure = XCTestExpectation(description: "Socket did secure")
+        didSecure.expectedFulfillmentCount = 2
+        let didReceiveTrust = XCTestExpectation(description: "Socket did receive trust")
+        
+        accepted.onReceiveTrust = { _ in
+            didReceiveTrust.fulfill()
+            return true
+        }
+        accepted.startTLS(as: .server, additionalSettings: [
+            GCDAsyncSocketManuallyEvaluateTrust: NSNumber(value: true),
+            GCDAsyncSocketSSLClientSideAuthenticate: NSNumber(value: SSLAuthenticate.tryAuthenticate.rawValue),
+        ]) {
+            didSecure.fulfill()
+        }
+
+        client.startTLS(as: .client) {
+            didSecure.fulfill()
+        }
+
+        waiter.wait(for: [didReceiveTrust, didSecure], timeout: TestSocket.waiterTimeout)
+    }
+    
+    func testDoNotManuallyEvaluate() {
+        let waiter = XCTWaiter(delegate: TestSocket.waiterDelegate)
+        let didSecure = XCTestExpectation(description: "Socket did secure")
+        didSecure.expectedFulfillmentCount = 2
+        
+        accepted.onReceiveTrust = { _ in
+            XCTFail("Socket should not receive trust")
+            return false
+        }
+        accepted.startTLS(as: .server) {
+            didSecure.fulfill()
+        }
+
+        client.startTLS(as: .client) {
+            didSecure.fulfill()
+        }
+
+        waiter.wait(for: [didSecure], timeout: TestSocket.waiterTimeout)
+    }
+}


### PR DESCRIPTION
- Enable `GCDAsyncSocketManuallyEvaluateTrust` for server socket
- Add `GCDAsyncSocketSSLClientSideAuthenticate` to allow customizing `SSLSetClientSideAuthenticate` parameter
- Add tests and documentation

This is similar to https://github.com/robbiehanson/CocoaAsyncSocket/pull/505, except that `GCDAsyncSocketSSLClientSideAuthenticate` cannot be set as `kNeverAuthenticate` since that's the default and defeats the purpose of `GCDAsyncSocketManuallyEvaluateTrust` (based on my understanding of the official [documentation](https://developer.apple.com/documentation/security/sslauthenticate/neverauthenticate)).

It would be nice if you can also create a new release for this (which would be 7.7.0 following semantic versioning https://semver.org/)