### PR TITLE
Always resumeReadSource after flushSSLBuffers in maybeDequeueRead

### DIFF
--- a/Source/GCD/GCDAsyncSocket.m
+++ b/Source/GCD/GCDAsyncSocket.m
@@ -4712,14 +4712,11 @@ enum GCDAsyncSocketConfig
 			// 
 			// Be sure callbacks are enabled so we're notified about a disconnection.
 			
-			if ([preBuffer availableBytes] == 0)
-			{
-				if ([self usingCFStreamForTLS]) {
-					// Callbacks never disabled
-				}
-				else {
-					[self resumeReadSource];
-				}
+			if ([self usingCFStreamForTLS]) {
+				// Callbacks never disabled
+			}
+			else {
+				[self resumeReadSource];
 			}
 		}
 	}


### PR DESCRIPTION
Resolves an issue we found when the SSLRead(...) call in flushSSLBuffers returned errSSLWouldBlock. In this case, we would want to resumeReadSource so that the buffers can drain.

Fixes #798 