### PR TITLE
Fix iOS 16 crash by kCFStreamNetworkServiceTypeVoIP

### DIFF
--- a/Source/GCD/GCDAsyncSocket.m
+++ b/Source/GCD/GCDAsyncSocket.m
@@ -28,6 +28,7 @@
 #import <sys/uio.h>
 #import <sys/un.h>
 #import <unistd.h>
+#import <PushKit/PushKit.h>
 
 #if ! __has_feature(objc_arc)
 #warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
@@ -8200,8 +8201,8 @@ static void CFWriteStreamCallback (CFWriteStreamRef stream, CFStreamEventType ty
 	
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-	r1 = CFReadStreamSetProperty(readStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeVoIP);
-	r2 = CFWriteStreamSetProperty(writeStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeVoIP);
+	r1 = CFReadStreamSetProperty(readStream, kCFStreamNetworkServiceType, PKPushTypeVoIP);
+	r2 = CFWriteStreamSetProperty(writeStream, kCFStreamNetworkServiceType, PKPushTypeVoIP);
 #pragma clang diagnostic pop
 
 	if (!r1 || !r2)


### PR DESCRIPTION
Fix iOS 16 crash by deprecated API, kCFStreamNetworkServiceTypeVoIP is deprecated, use PKPushTypeVoIP in PushKit.
I see this PR [802](https://github.com/robbiehanson/CocoaAsyncSocket/pull/802), use kCFStreamNetworkServiceTypeBackground replace kCFStreamNetworkServiceTypeVoIP.

I fix the crash by use 802 code.

In my App, I user CocoaMQTT, and it depend CocoaAsyncSocket, my App crash when mqtt begin to connect:
```
Linked against modern SDK, VOIP socket will not wake. Use Local Push Connectivity instead

libsp.dylib`spd_checkin_socket.cold.1:

  0x221e28364 <+0>: adrp  x8, 141901

  0x221e28368 <+4>: adrp  x9, 0

  0x221e2836c <+8>: add  x9, x9, #0xa3f      ; "Linked against modern SDK, VOIP socket will not wake. Use Local Push Connectivity instead"

  0x221e28370 <+12>: str  x9, [x8, #0x400]

-> 0x221e28374 <+16>: brk  #0x1
```
So I read Foundation code what‘s wrong with `kCFStreamNetworkServiceTypeVoIP`：

```
/* deprecated network service type: */

CFN_EXPORT const CFStringRef kCFStreamNetworkServiceTypeVoIP       CF_DEPRECATED(10_7, 10_11, 4_0, 9_0, "use PushKit for VoIP control purposes");   // voice over IP control - this service type is deprecated in favor of using PushKit for VoIP control
```

kCFStreamNetworkServiceTypeVoIP is deprecated, and [issues 402](https://github.com/robbiehanson/CocoaAsyncSocket/issues/402) mention.

>Add #import to GCDAsyncSocket.m
#import <PushKit/PushKit.h>

>Replace in enableBackgroundingOnSocketWithCaveat
r1 = CFReadStreamSetProperty(readStream, kCFStreamNetworkServiceType, PKPushTypeVoIP); r2 = CFWriteStreamSetProperty(writeStream, kCFStreamNetworkServiceType, PKPushTypeVoIP);

Then I use PKPushTypeVoIP replace kCFStreamNetworkServiceTypeVoIP.

Great, it’s OK now.