### PR TITLE
Bump up MACOSX_DEPLOYMENT_TARGET to 10.13

### DIFF
--- a/CocoaAsyncSocket.xcodeproj/project.pbxproj
+++ b/CocoaAsyncSocket.xcodeproj/project.pbxproj
@@ -545,7 +545,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.robbiehanson.CocoaAsyncSocket;
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = macosx;
@@ -571,7 +571,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.robbiehanson.CocoaAsyncSocket;
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = macosx;


### PR DESCRIPTION
When building macos framework, XCode 14.3 throws the following error :

```
ld: file not found: /Applications/Xcode-14.3.1-Release.Candidate.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/arc/libarclite_macosx.a
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

XCode 14 seems to have dropped support for older OS version and removed libarclite. 
Resource: https://developer.apple.com/forums//thread/728021

Note: This error only affects building with carthage and cocoapods since they rely on the xcodeproj file. 
Swift Package Manager does not seem to be impacted.

## Edit:

This PR shouldn't be merged due to the following:

1. CocoaAsyncSocket is great for legacy macOS development where Xcode 14.3 is not available. Thus bumping up the version would impact older Xcode versions.
2. Alternatively, if you can use modern OS and tools - consider Network.framework.
3. The origin of the fix comes from a dependency tool (carthage) which an unnatural reason to bump up deployment versions (Aside from no deprecated API has been cleaned up ).

Thats said, to unblock your build issues. You have the following options:
1. Use SPM,  Cocoapods or manually link CocoaAsyncSocket to your project. 
2. Pass in  deployment versions via xcodebuild
3. Copy over missing libarclite files over to you Xcode according to [here](https://rattle-cornucopia-d72.notion.site/Xcode-Project-Build-Error-missing-files-libarclite_iphonesimulator-a-e56022f7318e4685a8794be79d4bd28a) (Not recommended since it doesn't solve the underlying problem, just fixes the error )