### PR TITLE
kCFStreamNetworkServiceTypeVoIP update + ios16 crash workaround ref 

### DIFF
--- a/Source/GCD/GCDAsyncSocket.h
+++ b/Source/GCD/GCDAsyncSocket.h
@@ -988,8 +988,8 @@ typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
  * Configures the socket to allow it to operate when the iOS application has been backgrounded.
  * In other words, this method creates a read & write stream, and invokes:
  * 
- * CFReadStreamSetProperty(readStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeVoIP);
- * CFWriteStreamSetProperty(writeStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeVoIP);
+ * CFReadStreamSetProperty(readStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeBackground);
+ * CFWriteStreamSetProperty(writeStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeBackground);
  * 
  * Returns YES if successful, NO otherwise.
  * 

--- a/Source/GCD/GCDAsyncSocket.m
+++ b/Source/GCD/GCDAsyncSocket.m
@@ -3058,7 +3058,7 @@ enum GCDAsyncSocketConfig
 	// 
 	// Note:
 	// There may be configuration options that must be set by the delegate before opening the streams.
-	// The primary example is the kCFStreamNetworkServiceTypeVoIP flag, which only works on an unopened stream.
+    // The primary example is the `kCFStreamNetworkServiceTypeBackground` flag, which only works on an unopened stream.
 	// 
 	// Thus we wait until after the socket:didConnectToHost:port: delegate method has completed.
 	// This gives the delegate time to properly configure the streams if needed.
@@ -8283,8 +8283,8 @@ static void CFWriteStreamCallback (CFWriteStreamRef stream, CFStreamEventType ty
 	
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-	r1 = CFReadStreamSetProperty(readStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeVoIP);
-	r2 = CFWriteStreamSetProperty(writeStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeVoIP);
+	r1 = CFReadStreamSetProperty(readStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeBackground);
+	r2 = CFWriteStreamSetProperty(writeStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeBackground);
 #pragma clang diagnostic pop
 
 	if (!r1 || !r2)

--- a/Source/GCD/GCDAsyncSocket.m
+++ b/Source/GCD/GCDAsyncSocket.m
@@ -28,6 +28,8 @@
 #import <sys/uio.h>
 #import <sys/un.h>
 #import <unistd.h>
+#import <mach/mach_init.h>
+#import <mach/vm_map.h>
 
 #if ! __has_feature(objc_arc)
 #warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
@@ -129,6 +131,70 @@ NSString *const GCDAsyncSocketSSLALPN = @"GCDAsyncSocketSSLALPN";
 #if !TARGET_OS_IPHONE
 NSString *const GCDAsyncSocketSSLDiffieHellmanParameters = @"GCDAsyncSocketSSLDiffieHellmanParameters";
 #endif
+
+// patch CFSocket at runtime to work around a crash
+
+// first, create structs declaring our assumptions of where the needed internal data structures are located
+// this workaround will fail if Apple updates CFSocket to change these structure shapes
+// that _probably_ won't happen because CFSocket is deprecated in favor of the new Network framework
+
+struct __CFSocket {
+    int64_t offset[27];
+    CFSocketContext _context; /* immutable */
+};
+
+typedef struct {
+    int64_t offset[33];
+    struct __CFSocket *_socket;
+} __CFSocketStreamContext;
+
+struct __CFStream {
+    int64_t offset[5];
+    __CFSocketStreamContext *info;
+};
+
+/// safely copies memory from the stack, telling you if it was successful
+static inline vm_size_t copySafely(const void* restrict const src, void* restrict const dst, const vm_size_t byteCount)
+{
+    vm_size_t bytesCopied = 0;
+    kern_return_t result = vm_read_overwrite(mach_task_self(),
+                                             (vm_address_t)src,
+                                             byteCount,
+                                             (vm_address_t)dst,
+                                             &bytesCopied);
+    if (result != KERN_SUCCESS) return 0;
+    return bytesCopied;
+}
+
+/// a 10KB space on the stack for the following function to use. can be safely static because we never read from it
+static char g_memoryTestBuffer[10240];
+/// test if some stack memory is safely readable, to see if unsafe casts will segfault
+static inline bool isMemoryReadable(const void* const memory, const size_t byteCount)
+{
+    const int testBufferSize = sizeof(g_memoryTestBuffer);
+    vm_size_t bytesRemaining = byteCount;
+
+    while (bytesRemaining > 0) {
+        vm_size_t bytesToCopy = bytesRemaining > testBufferSize ? testBufferSize : bytesRemaining;
+        if (copySafely(memory, g_memoryTestBuffer, bytesToCopy) != bytesToCopy) {
+            break;
+        }
+        bytesRemaining -= bytesToCopy;
+    }
+    return bytesRemaining == 0;
+}
+
+/// a static serial queue so that socket context release calls get different threads
+static dispatch_queue_t socket_context_release_queue = nil;
+void (*origin_context_release)(const void *info);
+void new_context_release(const void *info) {
+    if (socket_context_release_queue == nil) {
+        socket_context_release_queue = dispatch_queue_create("socketContextReleaseQueue", 0x0);
+    }
+    dispatch_async(socket_context_release_queue, ^{
+        origin_context_release(info);
+    });
+}
 
 enum GCDAsyncSocketFlags
 {
@@ -3234,6 +3300,23 @@ enum GCDAsyncSocketConfig
 			}
 			if (writeStream)
 			{
+                // replace writeStream's context release function to avoid recursive lock crash
+                if (@available(iOS 16.0, *)) {
+                    struct __CFStream *cfstream  = (struct __CFStream *)writeStream;
+                    if (isMemoryReadable(cfstream, sizeof(*cfstream))
+                        && isMemoryReadable(cfstream->info, sizeof(*(cfstream->info)))
+                        && isMemoryReadable(cfstream->info->_socket, sizeof(*(cfstream->info->_socket)))
+                        && isMemoryReadable(&(cfstream->info->_socket->_context), sizeof(cfstream->info->_socket->_context))
+                        && isMemoryReadable(cfstream->info->_socket->_context.release, sizeof(*(cfstream->info->_socket->_context.release)))) {
+                        if (cfstream->info != NULL && cfstream->info->_socket != NULL) {
+                            if ((uintptr_t)cfstream->info->_socket->_context.release == (uintptr_t)CFRelease) {
+                                origin_context_release = cfstream->info->_socket->_context.release;
+                                cfstream->info->_socket->_context.release = new_context_release;
+                            }
+                        }
+                    }
+                }
+                
 				CFWriteStreamSetClient(writeStream, kCFStreamEventNone, NULL, NULL);
 				CFWriteStreamClose(writeStream);
 				CFRelease(writeStream);

--- a/Source/GCD/GCDAsyncUdpSocket.h
+++ b/Source/GCD/GCDAsyncUdpSocket.h
@@ -997,8 +997,8 @@ typedef BOOL (^GCDAsyncUdpSocketSendFilterBlock)(NSData *data, NSData *address, 
  * Configures the socket to allow it to operate when the iOS application has been backgrounded.
  * In other words, this method creates a read & write stream, and invokes:
  * 
- * CFReadStreamSetProperty(readStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeVoIP);
- * CFWriteStreamSetProperty(writeStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeVoIP);
+ * CFReadStreamSetProperty(readStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeBackground);
+ * CFWriteStreamSetProperty(writeStream, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeBackground);
  * 
  * Returns YES if successful, NO otherwise.
  * 

--- a/Source/GCD/GCDAsyncUdpSocket.m
+++ b/Source/GCD/GCDAsyncUdpSocket.m
@@ -5469,8 +5469,8 @@ Failed:
 //	
 //	if (readStream4 && writeStream4)
 //	{
-//		r1 = CFReadStreamSetProperty(readStream4, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeVoIP);
-//		r2 = CFWriteStreamSetProperty(writeStream4, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeVoIP);
+//		r1 = CFReadStreamSetProperty(readStream4, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeBackground);
+//		r2 = CFWriteStreamSetProperty(writeStream4, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeBackground);
 //		
 //		if (!r1 || !r2)
 //		{
@@ -5481,8 +5481,8 @@ Failed:
 //	
 //	if (readStream6 && writeStream6)
 //	{
-//		r1 = CFReadStreamSetProperty(readStream6, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeVoIP);
-//		r2 = CFWriteStreamSetProperty(writeStream6, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeVoIP);
+//		r1 = CFReadStreamSetProperty(readStream6, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeBackground);
+//		r2 = CFWriteStreamSetProperty(writeStream6, kCFStreamNetworkServiceType, kCFStreamNetworkServiceTypeBackground);
 //		
 //		if (!r1 || !r2)
 //		{


### PR DESCRIPTION
### Summary

1. Update VoIP stream constant to Background related to:
     - fix https://github.com/robbiehanson/CocoaAsyncSocket/issues/801 
     - https://github.com/robbiehanson/CocoaAsyncSocket/issues/815 
     - https://github.com/robbiehanson/CocoaAsyncSocket/issues/818
2.  Example for others curious about the issues around iOS16/CoreFoundation changes
     - similar: #824,  #803 
     - for details see: https://juejin.cn/post/7153606703399829511

Disclaimer: The code addressing the recursive lock crash is **unsafe** and doesn't completely resolve the issues causing the crash. Keeping in mind "The technologies underlying GCDAsyncSocket are either deprecated (CFSocketStream) or present solely for compatibility purposes (BSD Sockets)." - [developer.apple.com](https://developer.apple.com/forums/thread/707658])